### PR TITLE
mapped format to sourceResource (7637)

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,6 @@ class Item
     doc = transform_dotted_keys doc
     @id                     = doc['id']
     @sourceResource         = doc['sourceResource'] || {}
-    @originalRecord         = doc['originalRecord'] || {}
     @object                 = doc['object']
     @isShownAt              = doc['isShownAt']
     @dataProvider           = doc['dataProvider']


### PR DESCRIPTION
This change maps the `format` field to `sourceResource`, which is compliant with MAPV3.1.  It fixes [#7637](https://issues.dp.la/issues/7637). 
