### PR TITLE
List request size (7620)

### DIFF
--- a/app/controllers/saved_lists_controller.rb
+++ b/app/controllers/saved_lists_controller.rb
@@ -195,8 +195,11 @@ class SavedListsController < ApplicationController
 
     def get_api_items(saved_items_positions, search_param)
       api_items = {}.tap do |hash|
-        DPLA::Items.by_ids(saved_items_positions.map { |p| p.saved_item.item_id }, {q: search_param})
-          .each { |item| hash[item.id] = item } rescue nil
+        saved_items_positions.each_slice(50) do |slice| 
+          conditions = {:q => search_param, :page_size => '50'}
+          DPLA::Items.by_ids(slice.map { |p| p.saved_item.item_id }, conditions)
+            .each { |item| hash[item.id] = item } rescue nil
+        end
       end
     end
 

--- a/spec/controllers/saved_lists_controller_spec.rb
+++ b/spec/controllers/saved_lists_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe SavedListsController do
+
+	describe "#get_api_items" do
+
+		before(:each) do
+			@item1 = double('saved_items_positions', :saved_item => double('saved_item', :item_id => 'id1'))
+			@item2 = double('saved_items_positions', :saved_item => double('saved_item', :item_id => 'id2'))
+		end
+
+		it "sends correct params to DPLA::Items.by_ids" do
+			saved_items_positions = [@item1, @item2]
+			params = {:q => 'search_param', :page_size=>'50'}
+			DPLA::Items.should_receive(:by_ids).with(['id1', 'id2'], params)
+			@controller.instance_eval{get_api_items(saved_items_positions, 'search_param')}
+		end
+
+		it "returns aggregated search results" do			
+			saved_items_positions = [@item1, @item2]
+			api_result1 = double('item', :id => 'api_id1') 
+			api_result2 = double('item', :id => 'api_id2') 
+			DPLA::Items.stub(:by_ids).and_return([api_result1, api_result2])
+			result = @controller.instance_eval{get_api_items(saved_items_positions, '')}
+			result.should eq({
+				'api_id1' => api_result1,
+				'api_id2' => api_result2
+			})
+		end
+
+		it "constructs multiple API requests for long lists" do
+			saved_items_positions = []
+			101.times { saved_items_positions.push(@item1) } 
+			DPLA::Items.should_receive(:by_ids).exactly(3).times
+			@controller.instance_eval{get_api_items(saved_items_positions, 'search_param')}
+		end
+
+	end 
+
+end


### PR DESCRIPTION
This code limits the number of items requested and received when constructing lists to 50.
It fixes #7620.
See notes: https://issues.dp.la/issues/7620
