### PR TITLE
Gif it up link (7721)

### DIFF
--- a/app/views/shared/_top_navigation.html.haml
+++ b/app/views/shared/_top_navigation.html.haml
@@ -42,6 +42,7 @@
       %li= link_to "Follow Us", wordpress_path('/get-involved/follow/')
       %li= link_to "Forums", wordpress_path('/forums/')
       %li= link_to "Shop", wordpress_path('/get-involved/shop/')
+      %li= link_to "GIF IT UP", wordpress_path('/gif-it-up/')
 
   %li.aboutMenu
     = link_to wordpress_path '/help/' do


### PR DESCRIPTION
Add "GIF IT UP" link to "Get involved" dropdown menu.  Link should resolve to "http://dp.la/info/gif-it-up/".  Fixes #7721.
