### PR TITLE
change slide images and captions

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -8,35 +8,41 @@
         .flexslider.homeslide
           %ul.slides
             %li
-              = image_tag "slide/home-slide1.jpg"
+              = image_tag "slide/home-slide7.png"
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/280233fc9e42a02d32d268fe284a7613'} Laura Clay and group marching for the Madison, Fayette, and Franklin Kentucky Equal Rights Association, at Democratic National Convention in St. Louis, [n.d.] St. Louis, MO&nbsp;»
+                  %a{:href => '/item/92028cc0c0064c6690a39a6d67b11fde'} Americae Sive Novi Orbis Nova Descriptio, 1587. Ortelius Abraham, cartographer&nbsp;»
             %li
-              = image_tag "slide/home-slide2.jpg"
+              = image_tag "slide/home-slide8.jpg"
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/123c3ea1d7f099da675ce7c3a6c0ca4b'} An illuminated manuscript page from The Book of Hours, dated 1514&nbsp;»
+                  %a{:href => '/item/5316c911c73b2d4b44b3654b4ac9dea0'} Unidentified popper at the Roseland Ballroom, 1982. Joe Conzo, photographer&nbsp;»
             %li
-              = image_tag "slide/home-slide3.jpg"
+              = image_tag "slide/home-slide9.jpg"
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/7ba1d607106bf46b1c3775498f4de5ba'} Indian women playing game of plum stones. This is a print by the artist and military officer Seth Eastman, who was stationed in Minnesota before statehood&nbsp;»
+                  %a{:href => '/item/f156f66389fd98682d8280b9c3d1c46f'} An Ordinance Abolishing Slavery in Missouri, 1865. (Missouri Emancipation Proclamation)&nbsp;»
             %li
-              = image_tag "slide/home-slide4.jpg"
+              = image_tag "slide/home-slide10.jpg"
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/a699e705f5a48eeec323f12b171e5c5f'} Bandanna printed in red overall with left portrait legend &ldquo;PRESIDENT/GROVER CLEVELAND&rdquo; and right portrait legend &ldquo;VICE PRESIDENT/THOMAS A. HENDRICKS&rdquo;&nbsp;»
+                  %a{:href => '/item/58eba7947b48cc83bc8730587a3a6aab'} Winnie-the-Pooh, Kanga, Piglet, Eeyore, and Tigger, 1925&nbsp;»
             %li
-              = image_tag "slide/home-slide5.jpg"
+              = image_tag "slide/home-slide11.png"
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/53d404ae82e469c8d3aa73a19827805b'} Benjamin Sewall Blake jumping, ca. 1888. Francis Blake, photographer&nbsp;»
+                  %a{:href => '/item/75437b69bc3588e1ebc6fd2d1eb302b1'} Women on The Scrambler, Excelsior Amusement Park, Excelsior, Minnesota, c. 1950-1959.  &nbsp;»
+            %li
+              = image_tag "slide/home-slide12.jpeg"
+              .slideOverlay
+              .slideText
+                %p
+                  %a{:href => '/item/d498d3ce75e3fede0f8b4bd79fdc7146'} Mexican Folk Dancing, 9th Annual Texas Folklife Festival, 1980. Photograph by Michael Sidoric, Informedia&nbsp;»
           %a.moreInfo
             %span i
       .searchForm


### PR DESCRIPTION
This changes out the carousel images on the homepage.  It should be deployed with `https://github.com/dpla/frontend-assets/pull/1`.
