### PR TITLE
add tooltips for search view icons

### DIFF
--- a/app/views/shared/_search_panel.html.haml
+++ b/app/views/shared/_search_panel.html.haml
@@ -9,19 +9,19 @@
         %ul
           %li{class: params[:controller] == 'search' && 'active'}
             = link_to search_path(params.except(:controller, :action)) do
-              %span.icon-view-list{"aria-hidden" => "true"}
+              %span.icon-view-list{"aria-hidden" => "true", :title => "List"}
               %span.visuallyhidden List
           %li{class: params[:controller] == 'map' && 'active'}
             = link_to map_path(params.except(:controller, :action)), class: 'viewTwo' do
-              %span.icon-view-map{"aria-hidden" => "true"}
+              %span.icon-view-map{"aria-hidden" => "true", :title => "Map"}
               %span.visuallyhidden Map
           %li{class: params[:controller] == 'timeline' && 'active'}
             = link_to timeline_path(params.except(:controller, :action)), class: 'viewThree' do
-              %span.icon-view-time{"aria-hidden" => "true"}
+              %span.icon-view-time{"aria-hidden" => "true", :title => "Timeline"}
               %span.visuallyhidden Timeline
           %li{class: params[:controller] == 'bookshelf' && 'active'}
             = link_to bookshelf_path(params.except(:controller, :action)), class: 'viewFour' do
-              %span.icon-view-stack{"aria-hidden" => "true"}
+              %span.icon-view-stack{"aria-hidden" => "true", :title => "Bookshelf"}
               %span.visuallyhidden Bookshelf
     %a.search-btn{:href => ""}
       %span.icon-mag-glass{"aria-hidden" => "true"}


### PR DESCRIPTION
This adds a title attribute to the search view icons.  The title attribute will show up as a tooltip in all major browsers, appearing when a cursor hovers over the icon.  This addresses the need to clarify the icons in task #7752 https://issues.dp.la/issues/7752