### PR TITLE
remove border around search view explanations

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -310,12 +310,6 @@ h4 span { font-family: 'source_sans_pro_semiboldRg', arial, sans-serif; }
 
 a:hover { text-decoration: underline; color: #2b2b2b; }
 
-.message {
-    display: inline-block;
-    border: 1px solid #bebebe;
-    padding: .3em .5em;
-    margin: .3em 1em 1em 0 !important;
-}
 .highlight {
     background: #ededed;
     padding: 1em !important;
@@ -1004,7 +998,7 @@ article .shareSave { margin: 0 0 3% 74.286%; }
 .searchResults a { color: #2795b6; margin-left: 8px; }
 .searchResults ul li a:hover { text-decoration: none; }
 
-.searchResults h4 { float: left; font-size: 1.2em; color: #2b2b2b; margin-right: 1em;}
+.searchResults p { float: left; font-size: 1.2em; color: #2b2b2b; margin-right: 1em;}
 
 .no-results h4 {
     float: none;

--- a/app/views/shared/results/_search_results.html.haml
+++ b/app/views/shared/results/_search_results.html.haml
@@ -1,21 +1,22 @@
 / Search results block
 - if @search.count > 0
   .searchResults
-    %h4
+    %p
       Your search
       - if query.present?
         for
         %span= query
       returned
       = number_with_delimiter search.count, delimiter: ','
-      results.
-    - if 'map' == params[:controller]
-      %p.message Only results with location data are shown below.
-    - elsif 'timeline' == params[:controller]
-      %p.message Only results with time data are shown below.
-    - elsif 'bookshelf' == params[:controller]
-      %p.message Only book and periodical results are shown below.
-    = render 'shared/results/refined_by', search: search
+      - if 'map' == params[:controller]
+        results. Only results with location data are shown below.
+      - elsif 'timeline' == params[:controller]
+        results. Only results with time data are shown below.
+      - elsif 'bookshelf' == params[:controller]
+        books and periodicals.
+      -else
+        results.
+      = render 'shared/results/refined_by', search: search
 - else
   .searchResults.no-results#content{role: "main"}
     %h4


### PR DESCRIPTION
This changes the styling of the message that appears on `/search`, `/map`, `/timeline`, and `/bookshelf` telling people how many results their query returned, and how their results are presented on data visualizations.  It removes the box around the latter part of the message so that it no longer looks like a button.  It also changes the HTML element from `h4` to `p`, which is more accurate markup.  