### PR TITLE
Show facets by default map and timeline.

### DIFF
--- a/app/assets/javascripts/vendor/main.js
+++ b/app/assets/javascripts/vendor/main.js
@@ -148,7 +148,7 @@ if ($('.shareSave').length) {
       $('aside').addClass('moveOut');
       $('.slidePopOut').addClass('moveIn');
       $('.map article, .timeContainer').addClass('widthL');
-      $('.toggle').html('Show <span aria-hidden="true" class="icon-arrow-thin-right"></span>');
+      $('.toggle').html('Refine search <span aria-hidden="true" class="icon-arrow-thin-right"></span>');
 
       $('aside').removeClass('moveIn');
       $('.slidePopOut').removeClass('moveOut');
@@ -170,7 +170,7 @@ if ($('.shareSave').length) {
   $('.toggle.Marticle').toggle( function() {
       $('aside').addClass('moveIn');
       $('.map article, .timeContainer, .slidePopOut').addClass('moveOut');
-      $('.toggle.Marticle').html('<span aria-hidden="true" class="icon-arrow-thin-left"></span> Hide');
+      $('.toggle.Marticle').html('<span aria-hidden="true" class="icon-arrow-thin-left"></span> Search results');
 
       $('aside').removeClass('moveOut');
       $('.map article, .timeContainer, .slidePopOut').removeClass('moveIn');
@@ -178,7 +178,7 @@ if ($('.shareSave').length) {
     function() {
       $('aside').addClass('moveOut');
       $('.map article, .timeContainer, .slidePopOut').addClass('moveIn');
-      $('.toggle.Marticle').html('Show <span aria-hidden="true" class="icon-arrow-thin-right"></span>');
+      $('.toggle.Marticle').html('Refine search <span aria-hidden="true" class="icon-arrow-thin-right"></span>');
 
       $('aside').removeClass('moveIn');
       $('.map article, .timeContainer, .slidePopOut').removeClass('moveOut');

--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -3434,7 +3434,7 @@ div.timeline-year {
 }
 
 .map article.moveOut, .slidePopOut.moveOut, .timeContainer.moveOut {
-    margin-right: -106%;
+    margin-right: -106% !important;
     -webkit-transition: 0.3s ease;
     -moz-transition: 0.3s ease;
     -o-transition: 0.3s ease;
@@ -3453,8 +3453,18 @@ div.timeline-year {
     transition: 0.3s ease;
 }
 
-.map article.widthS, .timeContainer.widthS {
+.timeContainer.widthS {
     width: 65.8201%;
+    -webkit-transition: 0.3s ease;
+    -moz-transition: 0.3s ease;
+    -o-transition: 0.3s ease;
+    -ms-transition: 0.3s ease;
+    transition: 0.3s ease;
+}
+
+.map article.widthS {
+    width: 100%;
+    margin-right: -34.1799%;
     -webkit-transition: 0.3s ease;
     -moz-transition: 0.3s ease;
     -o-transition: 0.3s ease;
@@ -4192,6 +4202,7 @@ aside { height: 100%; }
 
 .map article.widthS, .timeContainer.widthS {
     width: 100%;
+    margin: 0;
 }
 
 .mapBox { width: 280px; }

--- a/app/views/map/show.html.haml
+++ b/app/views/map/show.html.haml
@@ -9,8 +9,7 @@
   - if @search.count > 0
     = render 'shared/refine_control'
 
-    - aside_collapses = params[:controller] != 'search'
-    %article#content{class: aside_collapses ? 'widthL' : 'widthS', role: "main"}
+    %article#content{class: 'widthS', role: "main"}
       .mapContainer
         .mobile-hover
         .mapFrame

--- a/app/views/shared/_aside_toggle.html.haml
+++ b/app/views/shared/_aside_toggle.html.haml
@@ -1,7 +1,7 @@
 - if @search.count > 0
   .toggle.mobile.Marticle
-    %span.icon-arrow-thin-left{"aria-hidden" => "true"}
-    Refine
+    Refine search
+    %span.icon-arrow-thin-right{"aria-hidden" => "true"}
   .toggle.mobile.Maside
-    Refine
+    Refine search
     %span.icon-arrow-thin-right{"aria-hidden" => "true"}

--- a/app/views/shared/_refine_control.html.haml
+++ b/app/views/shared/_refine_control.html.haml
@@ -1,16 +1,7 @@
-- aside_collapsed = params[:controller] != 'search'
 .controls
-  - if aside_collapsed
-    .toggle
-      Show
-      %span.icon-arrow-thin-right{"aria-hidden" => "true"}
-    .toggle.mobile.Marticle
-      Show
-      %span.icon-arrow-thin-right{"aria-hidden" => "true"}
-  - else
-    .toggle
-      %span.icon-arrow-thin-left{"aria-hidden" => "true"}
-      Hide
-    .toggle.mobile.Marticle
-      %span.icon-arrow-thin-left{"aria-hidden" => "true"}
-      Hide
+  .toggle
+    %span.icon-arrow-thin-left{"aria-hidden" => "true"}
+    Hide
+  .toggle.mobile.Marticle
+    Refine search
+    %span.icon-arrow-thin-right{"aria-hidden" => "true"}

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -1,8 +1,5 @@
-- aside_collapsed = %w(timeline map).include? params[:controller]
-
-%aside{class: aside_collapsed ? 'moveOut' : nil}
-  - if %w(search bookshelf).include? params[:controller]
-    %h5 Refine
+%aside
+  %h5 Refine search
   - unless params[:controller] == 'bookshelf'
     = render 'shared/sidebar/refine_by_type'
   = render 'shared/sidebar/refine_by_provider'

--- a/app/views/timeline/show.html.haml
+++ b/app/views/timeline/show.html.haml
@@ -10,8 +10,7 @@
     = render 'shared/refine_control'
 
     / Main container
-    - aside_collapsed = params[:controller] != 'search'
-    .timeContainer.decadesView{class: aside_collapsed ? 'widthL' : 'widthS'}
+    .timeContainer.decadesView{class: 'widthS'}
       %article.timeline#content{role: "main"}
         / Century timeline
         = render 'timeline_module'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,7 @@ ui:
         - sound
       video:
   maps:
-    center: [38, -93]
+    center: [36, -77]
     zoom:
       start: 4
       min:  4


### PR DESCRIPTION
This shows facets by default on `/map` and `/timeline` views.  
It also clarifies the language on the buttons that hide and show the facets.
This has been tested locally in desktop and mobile views.

This addresses task #7756 https://issues.dp.la/issues/7756