### PR TITLE
add map instructions

### DIFF
--- a/app/views/map/show.html.haml
+++ b/app/views/map/show.html.haml
@@ -7,6 +7,7 @@
   %h1 Map
   = render 'shared/results/search_results', query: params[:q], search: @search
   - if @search.count > 0
+    %p Click on a circle to see items about that location.
     = render 'shared/refine_control'
 
     - aside_collapses = params[:controller] != 'search'


### PR DESCRIPTION
This adds a sentence of instructions for the map view.
This fixes task #7759 https://issues.dp.la/issues/7759