### PR TITLE
move and restyle map instructions

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -1028,6 +1028,12 @@ article .shareSave { margin: 0 0 3% 74.286%; }
         padding: 0;
     }
 
+.searchInstructions { 
+    font-size: 1em; 
+    color: #2b2b2b; 
+    margin: 5px 0 1em; 
+}
+
 .refine { clear: both; }
 
 .pagination {
@@ -4135,6 +4141,8 @@ input[type="text"] { width: 80%; }
 
 .searchViews.off, .search-btn.off { display: none; }
 
+.searchInstructions { padding: 0 2.6455%; width: 94.709%; }
+
 /* ASIDE */
 .formRow select { width: 30%; margin-bottom: 10px; }
 .sideNav { width: 100%; }
@@ -4196,6 +4204,7 @@ aside { height: 100%; }
 
 .map article.widthS, .timeContainer.widthS {
     width: 100%;
+    padding: 0;
     margin: 0;
 }
 

--- a/app/views/map/show.html.haml
+++ b/app/views/map/show.html.haml
@@ -7,10 +7,11 @@
   %h1 Map
   = render 'shared/results/search_results', query: params[:q], search: @search
   - if @search.count > 0
-    %p Click on a circle to see items about that location.
+
     = render 'shared/refine_control'
 
     %article#content{class: 'widthS', role: "main"}
+      .searchInstructions Click on a circle to see items about that location.
       .mapContainer
         .mobile-hover
         .mapFrame


### PR DESCRIPTION
This addresses tasks 7756 and 7759.  Two previous branches have addressed these tasks and were both merged to master and deployed to staging.  Once on stating, I tested the previous commits on mobile devices.  Based on this mobile testing, I was able to make the additional layout improvements in this branch.  

Links to tasks: https://issues.dp.la/issues/7756 https://issues.dp.la/issues/7759

This branch moves the map instructions so they are hidden when the map is hidden on mobile devices.  It also restyles the instructions and removes some inherited padding around the map.

This branch has been deployed to staging.