### PR TITLE
Track clickthough events on search, timeline, map, bookshelf, and ite…

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require backbone
 //= require_tree ./backbone
 //
+//= require google-analytics-events.js
 //= require search.js.coffee
 //= require timeline.js.coffee
 //= require spikes.js.coffee

--- a/app/assets/javascripts/backbone/models/timeline_item.js.coffee
+++ b/app/assets/javascripts/backbone/models/timeline_item.js.coffee
@@ -22,6 +22,7 @@ class DPLA.Models.TimelineItem extends Backbone.Model
       highlight:   false
       created_date:  created_date || ''
       data_provider: data_provider || ''
+      provider:    doc['provider.name'] || ''
 
 class DPLA.Collections.TimelineItems extends Backbone.Collection
   requestByYear: (year, options = {}) ->

--- a/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
@@ -1,4 +1,9 @@
-<section class="<%= item.highlight ? 'highlight' : '' %>">
+<%# data-* attributes are used in Google Analytics event tracking %>
+<section class="<%= item.highlight ? 'highlight' : '' %>"
+         data-item-id="<%= item.id %>"
+         data-provider="<%= item.provider %>"
+         data-data-provider="<%= item.data_provider %>"
+         data-title="<%= item.title %>">
   <% back_uri = encodeURIComponent(window.location.href); %>
   <div class="sectionRight">
     <a href="/item/<%= item.id %>?back_uri=<%= back_uri %>">

--- a/app/assets/javascripts/google-analytics-events.js
+++ b/app/assets/javascripts/google-analytics-events.js
@@ -1,0 +1,53 @@
+/*
+ * Tracks custom events with Google Analytics.
+ * This application uses the google-analytics-rails gem to track general usage
+ * data. This file defines additional user interations to be tracked with Google
+ * Analtyics.
+ * See https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+ */
+
+$(function(){
+
+  // Track item view when items#show page loads.
+  $(document).ready(function(){
+    if ($('.items-controller.show-action').length > 0) {
+      trackItemViewEvent();
+    }
+  });
+
+  /*
+   * Bind event to a.ViewObject links to track click-throughs to external
+   * provider pages.  Assumes that all relevlant links have 'ViewObject' class.
+   */
+  $('body').on('click', '.ViewObject', function(){
+    event.preventDefault();
+    trackClickThroughEvent(this);
+    window.open(this.href, '_blank');
+  });
+});
+
+/* Track pageview of an internal DPLA item page.
+ * Relies on data-* attributes embedded in the HTML of the page.
+ */
+var trackItemViewEvent = function(){
+  var item = $("[data-item-id]");
+  var category = "View Item : " + item.attr("data-provider");
+  var action = item.attr("data-data-provider");
+  var label = item.attr("data-item-id") + " : " + item.attr("data-title");
+
+  ga('send', 'event', category, action, label);
+}
+
+/* 
+ * Track click-throughs to external provider pages.
+ * @param HTML object to which the event is bound.
+ * Relies on data-* attributes belonging to a parent of the given object.
+ */
+var trackClickThroughEvent = function(obj){
+  var item = $(obj).parents("[data-item-id]");
+  var category = "Click Through : " + item.attr("data-provider");
+  var action = item.attr("data-data-provider");
+  var label = item.attr("data-item-id") + " : " + item.attr("data-title");
+
+  ga('send', 'event', category, action, label, {'transport': 'beacon'});
+}

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -177,8 +177,8 @@ DPLAMap = L.Class.extend
           <h4><a href="#{ item_href }" target="_blank">#{ item_title }</a></h4>
           <p><span> #{ point.creator }</span></p>
           <p><span> #{ point.created_date }</span></p>
-
-          <a class="ViewObject" href="#{ point.url }" target="_blank">
+          <a class="ViewObject" href="#{ point.url }" target="_blank"
+             onclick="trackClickThroughEvent(this);">
             Get full #{ item_type } from #{ item_data_provider }
             <span class="icon-view-object" aria-hidden="true"></span>
           </a>
@@ -190,8 +190,13 @@ DPLAMap = L.Class.extend
           when point.type == "video" then window.default_images.video
           else default_images.text
         html +=
+          # data-* attributes are used in Google Analytics event tracking
           """
-            <div class="box-row">
+            <div class="box-row"
+                 data-item-id="#{ point.id }"
+                 data-provider="#{ point.provider }"
+                 data-data-provider="#{ point.data_provider }"
+                 data-title="#{ point.title }">
               <div class="box-right"><a href="#{ item_href }" target="_blank"><img onerror="image_loading_error(this);" src="#{ point.thumbnail }" data-default-src="#{ default_image }" /></a></div>
               <div class="box-left">#{ content }</div>
             </div>
@@ -409,6 +414,7 @@ DPLAMap = L.Class.extend
       lng: coordinates.shift()
       created_date: created_date || ''
       data_provider: data_provider || ''
+      provider: doc['provider.name'] || ''
 
 DPLAPopup = L.Popup.extend
   _initLayout: ->

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -80,7 +80,7 @@ class Search
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
       sourceResource.spatial.name sourceResource.spatial.coordinates
-      sourceResource.date dataProvider
+      sourceResource.date provider.name dataProvider
     )
     conditions = DPLA::Conditions.new({ q: @term }.merge(@filters).merge(fields: fields))
     "#{api_base_path}/items?#{conditions}#{api_key}"

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -16,7 +16,7 @@ class Timeline < Search
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
       sourceResource.description sourceResource.date
-      dataProvider
+      provider.name dataProvider
     )
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,10 +6,15 @@
   %h1= @item.title || @item.id
   - if @item.titles.present?
     %h4= @item.titles.join(', ')
-  %article#content{role: "main"}
+  -# data-* attributes are used in Google Analytics event tracking
+  %article#content{ role: "main",
+                    data: { 'item-id' => @item.id,
+                            'provider' => @item.provider,
+                            'data-provider' => @item.data_provider,
+                            'title' => @item.title } }
     .FeatureContent
       .contentBox
-        = link_to @item.url, target: :_blank do
+        = link_to @item.url, target: :_blank, class: 'ViewObject' do
           = item_thumbnail(@item, request)
         = view_object_link(@item)
       .table
@@ -46,6 +51,7 @@
         -if @item.standardized_rights_statement.present?
           =item_field :standardized_rights_statement
         = item_field :url, title: 'URL'
+          = link_to @item.url, @item.url, target: :_blank, class: 'ViewObject'
 
   %aside
     - # is_location_present = @item.location.present? && @item.coordinates.present?
@@ -75,6 +81,3 @@
     /   %h5
     /     %a{:href => ""} Smithsonian Civil War Collection
     /   %p Description of this collection lorem ipsum dolor sit amet, consectetur adipiscing elit. In ac est leo. Cras sollicitudin volutpat nibh in blandit. Morbi ornare quam quis tortor pretium at hendrerit magna molestie. Cras facilisis, nulla non lobortis varius, tellus nibh elementum nibh, non accumsan augue augue ut augue.
-
-:javascript
-  #{analytics_track_event "View Item : #{@item.try(:provider)}", "#{@item.try(:contributing_institution)}", "#{@item.id} : #{@item.try(:title)}"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,8 @@
   = javascript_include_tag 'modernizr-2.6.2.min.js'
   <!--[if lte IE 7]>#{ javascript_include_tag 'lte-ie7.js' }<![endif]-->
   = analytics_init
-%body{class: "#{params[:controller]}-controller"}
+-# body class names make each page identifiable by controller and action
+%body{class: "#{controller_name}-controller #{action_name}-action"}
   %ul.jump-links
     %li
       %a{:href => "#top-nav", "accesskey" => "1"} Go to top navigation

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -16,7 +16,11 @@
         = render partial: 'matches'
         .search
           - @items.each do |item|
-            %section
+            -# data-* attributes are used in Google Analytics event tracking
+            %section{ data: { 'item-id' => item.id,
+                              'provider' => item.provider,
+                              'data-provider' => item.data_provider,
+                              'title' => item.title } }
               .searchRight
                 = link_to item_thumbnail(item, request), item_path(item.id, back_uri: request.url)
               .searchLeft


### PR DESCRIPTION
This tracks click-through events on /search, /timeline, /map, and /item pages with Google Analytics.  It also refactors the code to track pageviews of /item pages as events.

A click-through event is triggered when a user clicks a link to an external provider page.  A view-item event is triggered when a user views an internal DPLA item page.  Each event captures the item's `ID`, `title`, `provider`, and `dataProvider`.

The HTML `data-*` attribute embeds the relevant metadata for each item in the page, making it accessible to JavaScript functions.  Using the `data-` attribute separates the event tracking functionality from the item presentation, and allows all relevant metadata to be stored in a single DOM element (which makes the JavaScript simpler).  For info on the `data-*` attribute, see http://www.w3schools.com/tags/att_global_data.asp.

JQuery functions bind Google Analytics event tracking to the appropriate elements when relevant DOM elements have loaded.  The JavaScript is unobtrusive on /item and /search pages (this has been confirmed by testing in a JQuery-disabled browser).  Unobtrusive JavaScript is currently not a concern in /map and /timeline pages, which rely on JavaScript to function.

The end result in Google Analytics is this:

*Sample click-through event data:*
Category: `Click Through : California Digital Library`
Action: `UC Berkeley, Berkeley Art Museum/Pacific Film Archive`
Label: `4f9ac8f5c69822063984031178cbd713 : Yellow Table on Yellow Background`

*Sample view-item event data:*
Category: `View Item : California Digital Library`
Action: `UC Berkeley, Berkeley Art Museum/Pacific Film Archive`
Label: `4f9ac8f5c69822063984031178cbd713 : Yellow Table on Yellow Background`

This also improves the "Action" message.  Before, the action was displayed as a string literal representation of an array, ie. `["UC Berkeley, Berkeley Art Museum/Pacific Film Archive"]`, and now, as shown above, it is just a string.  This will make it nicer for hubs reading their stats in the Google Analytics dashboard.

This has been tested on staging using the [Google Analytics debugger plugin](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna).  It addresses [task #7823](https://issues.dp.la/issues/7823) and [task #8442](https://issues.dp.la/issues/8442).