### PR TITLE
Fix devise and better_errors versions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem 'thin'
   gem 'capistrano-deploy', :require => false
   gem 'quiet_assets'
-  gem 'better_errors', '~> 0.1'
+  gem 'better_errors', '~> 1.0'
   gem 'binding_of_caller'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'page_title_helper'
 gem 'dalli'
 gem 'httparty'
 gem 'elastictastic'
-gem 'devise'
+gem 'devise', '~> 2.0'
 gem 'rails_config'
 gem "leaflet-rails", "~> 0.5.0"
 gem "leaflet-markercluster-rails", "~> 0.2.1"
@@ -37,7 +37,7 @@ group :development do
   gem 'thin'
   gem 'capistrano-deploy', :require => false
   gem 'quiet_assets'
-  gem 'better_errors'
+  gem 'better_errors', '~> 0.1'
   gem 'binding_of_caller'
 end
 


### PR DESCRIPTION
Add specific version limits to devise and better_errors gems, so that they do not upgrade to breaking version numbers, and so that new installations do not run into errors.  The latest version of better_errors wants Ruby 2 (while we are using 1.9), and devise v3+ requires changes to our configuration to avoid errors on startup, and is untested with our application.

A bundle update on an old installation will trigger the errors mentioned above.
