### PR TITLE
Remove facets from bookshelf query

### DIFF
--- a/app/controllers/bookshelf_controller.rb
+++ b/app/controllers/bookshelf_controller.rb
@@ -4,11 +4,13 @@ class BookshelfController < ApplicationController
   def show
     respond_to do |format|
       format.json do
-        @search = Search.new *permitted_params.search
+        # Bookshelf gives a list of books.
+        @search = Bookshelf.new *permitted_params.search
         @items = @search.result permitted_params.args
         render json: @items
       end
       format.html do
+        # This Search gives facets for the navigation.
         @search = Search.new permitted_params.term, permitted_params.filters,
                              { spec_type: 'Book', page_size: 0 }
         render :show

--- a/app/models/bookshelf.rb
+++ b/app/models/bookshelf.rb
@@ -10,6 +10,6 @@ require_dependency 'dpla/items'
 class Bookshelf < Search
 
   def conditions
-    { q: @term, facets: [], facet_size: 0 }.merge(@filters).merge(@args)
+    { q: @term }.merge(@filters).merge(@args)
   end
 end

--- a/app/models/bookshelf.rb
+++ b/app/models/bookshelf.rb
@@ -1,0 +1,15 @@
+require_dependency 'dpla/items'
+##
+# A model that represents a Book item retrieved from the search.
+#
+# For displaying the books in BookshelfController.
+# Search#conditions is overridden to forego the retrieval of facets.
+#
+# @see BookshelfController
+#
+class Bookshelf < Search
+
+  def conditions
+    { q: @term, facets: [], facet_size: 0 }.merge(@filters).merge(@args)
+  end
+end


### PR DESCRIPTION
Make one of the queries that's done for bookshelf items stop requesting facets.  The facets are not used and result, theoretically, in unnecessary work for the search servers.

I'm not sure how much this will cut down on the search servers' load, but the facets are unnecessary for the list of books.
