### PR TITLE
Limit the maximum page number that can be requested of the bookshelf

### DIFF
--- a/app/assets/javascripts/backbone/views/stacklife/base.js.coffee
+++ b/app/assets/javascripts/backbone/views/stacklife/base.js.coffee
@@ -3,6 +3,7 @@ DPLA.Views.Bookshelf = {}
 class DPLA.Views.Bookshelf.Base extends Backbone.View
   initialize: (options) ->
     super options
+    @options || (@options = options)
     @subviews = []
     @template = @template ? options.template
     @render()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,4 +28,8 @@ class ApplicationController < ActionController::Base
   def render_500
     render 'pages/error_500', status: 500
   end
+
+  def render_503
+    render nothing: true, status: 503
+  end
 end

--- a/app/controllers/bookshelf_controller.rb
+++ b/app/controllers/bookshelf_controller.rb
@@ -1,5 +1,6 @@
 class BookshelfController < ApplicationController
   helper_method :permitted_params
+  rescue_from Errors::PageLimitError, with: :render_503
 
   def show
     respond_to do |format|

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -27,7 +27,10 @@ class PermittedParams < Struct.new(:params)
   def args
     args = params.map do |key, value|
       case key
-      when 'page'       then [key, value]
+      when 'page' then
+        raise Errors::PageLimitError \
+          if value.to_i > Settings.bookshelf.max_pages.to_i
+        [key, value]
       when 'page_size'  then [key, value] if %w(10 20 50 100).include?(value)
       when 'sort_by'    then [key, value] if %w(title created).include?(value)
       when 'sort_order' then [key, value] if %w(asc desc).include?(value)
@@ -57,3 +60,4 @@ class PermittedParams < Struct.new(:params)
   end
 
 end
+

--- a/config/settings.local.yml.example
+++ b/config/settings.local.yml.example
@@ -57,3 +57,5 @@ fog:
     aws_secret_access_key: changeme
   directory: changeme
   # public: true
+bookshelf:
+  max_pages: 100

--- a/lib/errors/page_limit_error.rb
+++ b/lib/errors/page_limit_error.rb
@@ -1,0 +1,6 @@
+module Errors
+  ##
+  # Exception representing a higher-than-allowed page number having been
+  # requested
+  class PageLimitError < StandardError; end
+end


### PR DESCRIPTION
Have the BookshelfController respond with a 400 Bad Request if queried
with a page number that is above a configurable limit.

High page numbers can result in inefficient Elasticsearch queries.
See "Deep Paging in Distributed Systems," in
https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html

Also includes a fix to a Coffeescript file to fix an exception related to an object
being null sometimes.  (Which should remain its own commit.)
