### PR TITLE
Pin rails_config to version 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'dalli'
 gem 'httparty'
 gem 'elastictastic'
 gem 'devise', '~> 2.0'
-gem 'rails_config'
+gem 'rails_config', '~> 0.4.0'
 gem "leaflet-rails", "~> 0.5.0"
 gem "leaflet-markercluster-rails", "~> 0.2.1"
 gem 'google-analytics-rails'


### PR DESCRIPTION
Pin rails_config to version 0.4.0 to prevent the error
"NameError: uninitialized constant Settings." after a new install or a
bundle update.

Same issue as
https://github.com/dpla/KriKri/commit/23a81cb33827b80df2d40d2cab87c96c0311cd14