### PR TITLE
Ensure page limits are only enforced on bookshelf (fixes #7915)

### DIFF
--- a/app/controllers/bookshelf_controller.rb
+++ b/app/controllers/bookshelf_controller.rb
@@ -6,6 +6,8 @@ class BookshelfController < ApplicationController
     respond_to do |format|
       format.json do
         # Bookshelf gives a list of books.
+        raise Errors::PageLimitError if \
+          params['page'].to_i > Settings.bookshelf.max_pages.to_i
         @search = Bookshelf.new *permitted_params.search
         @items = @search.result permitted_params.args
         render json: @items

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -27,10 +27,7 @@ class PermittedParams < Struct.new(:params)
   def args
     args = params.map do |key, value|
       case key
-      when 'page' then
-        raise Errors::PageLimitError \
-          if value.to_i > Settings.bookshelf.max_pages.to_i
-        [key, value]
+      when 'page'       then [key, value]
       when 'page_size'  then [key, value] if %w(10 20 50 100).include?(value)
       when 'sort_by'    then [key, value] if %w(title created).include?(value)
       when 'sort_order' then [key, value] if %w(asc desc).include?(value)


### PR DESCRIPTION
dpla/frontend#62 was designed to limit high-paging into bookshelf search requests.
This introduced a regression where all requests that used a `:page` parameter would
fail past the value set for `bookshelf.max_pages` in the settings.