### PR TITLE
Pin rails-backbone to ~> 0.9.10 (fixes #7954)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
   gem 'therubyracer'
   gem 'jquery-rails'
-  gem 'rails-backbone'
+  gem 'rails-backbone', '~> 0.9.10'
 end
 
 gem 'haml'


### PR DESCRIPTION
**PLEASE TEST ALL FRONTEND BEHAVIOR IMPLEMENTED IN BACKBONE/COFFEESCRIPT WHEN TESTING.** The [related issue](https://issues.dp.la/issues/7954) concerns the bookshelf, but please also test the map and the timeline to ensure that there are no regressions. 

Because of a change in our deployment processes introduced by dpla/automation#95, rails-backbone was being updated automatically. I'm not sure if it's an issue with this gem itself or one if its dependencies, but pinning it has the side effect of also pinning coffee-script, ejs, and jquery-rails.