### PR TITLE
Changes to top-level menu items (fixes #8054)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem 'fog'
 
 group :development do
   gem 'thin'
-  gem 'capistrano-deploy', :require => false
   gem 'quiet_assets'
   gem 'better_errors', '~> 1.0'
   gem 'binding_of_caller'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ gem "leaflet-markercluster-rails", "~> 0.2.1"
 gem 'google-analytics-rails'
 gem 'meta-tags'
 gem 'turnout'
-gem 'fog'
+gem 'net-ssh', '~> 2.1'
+gem 'fog', '~> 1.34'
+gem 'fog-google', '~> 0.0.7'
 
 group :development do
   gem 'thin'

--- a/app/views/shared/_top_navigation.html.haml
+++ b/app/views/shared/_top_navigation.html.haml
@@ -37,21 +37,19 @@
     %ul
       %li= link_to "Community Reps", wordpress_path('/get-involved/reps/')
       %li= link_to "Curation Corps", wordpress_path('/get-involved/dpla-ebooks/dpla-collection-curation-corps/')
+      %li= link_to "GIF IT UP", wordpress_path('/gif-it-up/gif-it-up-2015/')
       %li= link_to "Groups", wordpress_path('/get-involved/groups/')
       %li= link_to "Workshops", wordpress_path('/get-involved/workshops/')
       %li= link_to "Events", wordpress_path('/get-involved/events/')
       %li= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/')
       %li= link_to "Follow Us", wordpress_path('/get-involved/follow/')
-      %li= link_to "Shop", wordpress_path('/get-involved/shop/')
 
   %li.aboutMenu
     = link_to wordpress_path '/help/' do
       Help
       %span.icon-arrow-thin-down{"aria-hidden" => "true"}
     %ul
-      %li= link_to "Tutorials", wordpress_path('/help/tutorials/')
       %li= link_to "FAQ", wordpress_path('/help/faq/')
-      %li= link_to "DPLA Accounts", wordpress_path('/help/accounts/')
 
   %li.aboutMenu
     = link_to wordpress_path '/news/' do


### PR DESCRIPTION
* Add "GIF IT UP" under "Get Involved".
* Remove "Tutorials" from under "Help".
* Remove "Accounts" from under "Help".
* Remove "Shop" from under "Get Involved".