### PR TITLE
add date to search results

### DIFF
--- a/app/assets/javascripts/backbone/models/timeline_item.js.coffee
+++ b/app/assets/javascripts/backbone/models/timeline_item.js.coffee
@@ -6,6 +6,9 @@ class DPLA.Models.TimelineItem extends Backbone.Model
     description = doc['sourceResource.description'] || ''
     description = _.first(description) if _.isArray(description)
     description = description.substr(0, 200) + '...' if description.length > 200
+    date = doc['sourceResource.date']
+    created_date = date['displayDate'] if typeof date isnt 'undefined'
+    created_date = created_date.join(', ') if _.isArray(created_date)
     this.set
       id:          id
       type:        doc['sourceResource.type'] || ''
@@ -15,6 +18,7 @@ class DPLA.Models.TimelineItem extends Backbone.Model
       source:      doc['isShownAt'] || ''
       thumbnail:   doc['object']    || ''
       highlight:   false
+      created_date: created_date || ''
 
 class DPLA.Collections.TimelineItems extends Backbone.Collection
   requestByYear: (year, options = {}) ->

--- a/app/assets/javascripts/backbone/templates/bookshelf/bookPreview.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/bookshelf/bookPreview.jst.ejs
@@ -8,6 +8,13 @@ var presenter = {
 presenter.thumb = model.get('object') ?
                   model.get('object') :
                   window.default_preview_thumb;
+
+var created_date = (typeof sourceResource.date === 'undefined') ?
+                   '' : sourceResource.date.displayDate;
+
+presenter.created_date = Array.isArray(created_date) ?
+                         created_date.join(', ') : created_date
+
 _.each(['creator', 'title', 'description'], function(key) {
   presenter[key] = _.isArray(sourceResource[key]) ?
                    sourceResource[key].join(', ') :
@@ -22,6 +29,9 @@ _.each(['creator', 'title', 'description'], function(key) {
   <h2><a href="/item/<%= presenter.id %>"><%= presenter.title %></a></h2>
   <% if (presenter.creator) { %>
     <h3><%= presenter.creator %></h3>
+  <% } %>
+  <% if (presenter.created_date) { %>
+    <h3><%= presenter.created_date %></h3>
   <% } %>
 
   <p class="book-description"><%= presenter.description %></p>

--- a/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
@@ -7,6 +7,7 @@
     <% back_uri = encodeURIComponent(window.location.href); %>
     <a href="/item/<%= item.id %>?back_uri=<%= back_uri %>"><%= item.title %></a>
     <p><span><%= item.creator %></span></p>
+    <p><span><%= item.created_date %></span></p>
     <p><%= item.description %></p>
     <a href="<%= item.source %>" class="ViewObject" target="_blank">
       View Object

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -168,6 +168,8 @@ DPLAMap = L.Class.extend
           <h6> #{ point.type }</h6>
           <h4><a href="#{ item_href }" target="_blank">#{ item_title }</a></h4>
           <p><span> #{ point.creator }</span></p>
+          <p><span> #{ point.created_date }</span></p>
+
           <a class="ViewObject" href="#{ point.url }" target="_blank">View Object <span class="icon-view-object" aria-hidden="true"></span></a>
         """
       if point.thumbnail
@@ -379,6 +381,9 @@ DPLAMap = L.Class.extend
       coordinates = doc['sourceResource.spatial.coordinates'].split ','
     location = doc['sourceResource.spatial.name']
     location = [location] unless location instanceof Array
+    date = doc['sourceResource.date']
+    created_date = date['displayDate'] if typeof date isnt 'undefined'
+    created_date = created_date.join(', ') if _.isArray(created_date)
     point =
       id: doc.id
       title: doc['sourceResource.title'] || doc['id']
@@ -389,6 +394,7 @@ DPLAMap = L.Class.extend
       url: doc['isShownAt']
       lat: coordinates.shift()
       lng: coordinates.shift()
+      created_date: created_date || ''
 
 
 DPLAPopup = L.Popup.extend

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -80,6 +80,7 @@ class Search
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
       sourceResource.spatial.name sourceResource.spatial.coordinates
+      sourceResource.date
     )
     conditions = DPLA::Conditions.new({ q: @term }.merge(@filters).merge(fields: fields))
     "#{api_base_path}/items?#{conditions}#{api_key}"

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -15,7 +15,7 @@ class Timeline < Search
     %w(
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
-      sourceResource.description
+      sourceResource.description sourceResource.date
     )
   end
 

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -26,6 +26,8 @@
                   %h4= item.title
                 %p
                   %span= item.creator
+                %p
+                  %span= item.created_date.join(', ')
                 %p= truncate item.description, length: 450
                 - if item.url.present?
                   = link_to item.url, class: 'ViewObject', target: :_blank do


### PR DESCRIPTION
This adds each item's "created date" (ie. `sourceResource.date.displayDate`) to the search results for the list, map, timeline, and bookshelf views.  It addresses [ticket #7755](https://issues.dp.la/issues/7755).  

For those views relying on JavaScript (or CoffeeScript), the process involves:

1. Requesting `sourceResource.date` from the API.
2. Parsing `displayDate`, keeping in mind that:

  a. `sourceResource.date` or `displayDate` may be undefined

  b. `displayDate` may be a String or an Array
3. Showing the date in the view.