### PR TITLE
Ensure edm:object values are HTTP(S) URIs when building thumbnails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ script:
 rvm:
 - 1.9.3-p547
 sudo: false
+addons:
+    code_climate:
+        repo_token: cdf26a4bea16a6cf03275316e208edeb0aff96ebf3c937fd02943401c6f759c6

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :test, :development do
   gem 'shoulda-matchers'
   gem 'awesome_print'
   gem 'pry'
+  gem "codeclimate-test-reporter", group: :test, require: nil
 end
 
 group :test do

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -125,8 +125,10 @@ class Item
     @sourceResource['format']
   end
 
+  # @return [String, nil]  the preview image if it is a valid HTTP uri; nil otherwise
   def preview_image
-    @object
+    return @object if valid_http_uri?(@object)
+    nil
   end
 
   def data_provider
@@ -146,6 +148,12 @@ class Item
   end
 
   private
+
+    def valid_http_uri?(uri)
+      URI.parse(uri).kind_of?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+    end
 
     def transform_dotted_keys(doc)
       doc.keys

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Item do
+  describe "#preview_image" do
+    before(:each) do
+      allow(item).to receive(:preview_image).and_call_original
+    end
+
+    shared_examples 'an item with an object' do
+      let(:item) { Item.new({"object" => value}) }
+
+      it 'returns the expected thumbnail URI' do
+        expect(item.preview_image).to eq(ret)
+      end
+    end
+
+    context 'with a valid HTTP edm:object' do
+      let(:value) { 'http://example.com/1.png' }
+      let(:ret) { value }
+      it_behaves_like 'an item with an object'
+    end
+
+    context 'with a valid HTTPS edm:object' do
+      let(:value) { 'https://example.org/2.gif' }
+      let(:ret) { value }
+      it_behaves_like 'an item with an object'
+    end
+
+    context 'with a invalid URI value for edm:object' do
+      let(:value) { '_:b3f3f2f0' }
+      let(:ret) { nil }
+      it_behaves_like 'an item with an object'
+    end
+
+    context 'without an object' do
+      let(:item) { Item.new({"isShownAt" => "http://bar.com/foo"}) }
+
+      it 'returns nil when there is no object' do
+        expect(item.preview_image).to be_nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Let me know if you think this needs a test; there are no tests for the `Item` model at all yet. :disappointed_relieved: 