### PR TITLE
Update ebooks link in nav bar

### DIFF
--- a/app/views/shared/_top_navigation.html.haml
+++ b/app/views/shared/_top_navigation.html.haml
@@ -47,7 +47,7 @@
       %span.icon-arrow-thin-down{"aria-hidden" => "true"}
     %ul
       %li= link_to "Community Reps", wordpress_path('/get-involved/reps/')
-      %li= link_to "Curation Corps", wordpress_path('/get-involved/dpla-ebooks/dpla-collection-curation-corps/')
+      %li= link_to "Ebooks", wordpress_path('/get-involved/dpla-ebooks/')
       %li= link_to "GIF IT UP", wordpress_path('/gif-it-up/gif-it-up-2015/')
       %li= link_to "Groups", wordpress_path('/get-involved/groups/')
       %li= link_to "Workshops", wordpress_path('/get-involved/workshops/')


### PR DESCRIPTION
Change the "Curation Corps" link in the navbar to "Ebooks".  This addresses [ticket #8358](https://issues.dp.la/issues/8358).