### PR TITLE
Make verification of api's SSL cert optional

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,3 +30,6 @@ ui:
     grid_level: [7, 18]
     page_size: 500
     popup_page_size: 50
+
+api:
+  verify_ssl: true

--- a/lib/dpla/items.rb
+++ b/lib/dpla/items.rb
@@ -16,7 +16,9 @@ module DPLA
     end
 
     def self.load(query)
-      response = self.get query, query_string_normalizer: -> s {s}
+      response = self.get query,
+                          query_string_normalizer: -> s {s},
+                          verify: Settings.api.verify_ssl
       Rails.logger.debug "API: Processing request #{response.request.uri}"
       if response.code != 200
         Rails.logger.info [


### PR DESCRIPTION
Add a parameter to configure whether HTTParty verifies the SSL certificate of the API, if it's using SSL. This allows use of the frontend in a development setting with a self-signed certificate for the API.
