### PR TITLE
remove dplafest slide from homepage slideshow

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -8,12 +8,6 @@
         .flexslider.homeslide
           %ul.slides
             %li
-              = image_tag "slide/dplafest-2016.jpg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/info/get-involved/dplafest/april-2016/'} Join us for DPLAfest 2016, taking place on April 14-15, 2016 in Washington, DC!&nbsp;»
-            %li
               = image_tag "slide/home-slide-pss.jpg"
               .slideOverlay
               .slideText


### PR DESCRIPTION
This removes the DPLAfest 2016 slide from the homepage slideshow.  It addresses [ticket #8386](https://issues.dp.la/issues/8386).