### PR TITLE
Avoid setting Set-Cookie header unnecessarily

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   before_filter :sanitize_back_uri!
-  after_filter :set_cache_flag!
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from Exception, with: :render_500
 
@@ -21,15 +20,6 @@ class ApplicationController < ActionController::Base
     if params[:back_uri].present?
       ok = request.protocol + request.host
       render nothing: true, status: 403 if !params[:back_uri].start_with? ok
-    end
-  end
-
-  def set_cache_flag!
-    flag = Settings.session.logged_in_flag.to_sym
-    if current_user
-      cookies[flag] = { value: 1, httponly: true } if not cookies[flag]
-    else
-      cookies.delete flag
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,11 @@ class SessionsController < Devise::SessionsController
 
   def set_cache_flag!
     flag = Settings.session.logged_in_flag.to_sym
-    cookies[flag] = { value: 1, httponly: true } if not cookies[flag]
+    if current_user
+      cookies[flag] = { value: 1, httponly: true } if not cookies[flag]
+    else
+      cookies.delete flag
+    end
   end
 
   def new


### PR DESCRIPTION
Remove ApplicationController's behavior to unset the "no cache" cookie with every request for a user who is not logged-in. Instead, unset the cookie when a logged-in user logs out.