### PR TITLE
fix link to ncdhc item in homepage slider

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -30,7 +30,7 @@
               .slideOverlay
               .slideText
                 %p
-                  %a{:href => '/item/f156f66389fd98682d8280b9c3d1c46f'} An Ordinance Abolishing Slavery in Missouri, 1865. (Missouri Emancipation Proclamation)&nbsp;»
+                  %a{:href => '/item/7c26b9eff9d4c572b0a686d9207417a4'} An Ordinance Abolishing Slavery in Missouri, 1865. (Missouri Emancipation Proclamation)&nbsp;»
             %li
               = image_tag "slide/home-slide10.jpg"
               .slideOverlay


### PR DESCRIPTION
The current link to the NCDHC item in the homepage slider does not resolve.  Possibly its DPLA ID changed during a recent ingestion?  In any case, this PR fixes the URL.