### PR TITLE
display multiple types

### DIFF
--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -19,7 +19,7 @@
               .searchRight
                 = link_to item_thumbnail(item, request), item_path(item.id, back_uri: request.url)
               .searchLeft
-                %h6= item.type
+                %h6= Array.wrap(item.type).join(', ')
                 - if item.id.present?
                   %h4= link_to item.title || item.id, item_path(item.id, back_uri: request.url)
                 - else


### PR DESCRIPTION
This fixes the display of the "type" field in the search results list view.  Before, if there were multiple types, they would display as an array:

<img width="736" alt="screen shot 2016-06-24 at 12 02 11 pm" src="https://cloud.githubusercontent.com/assets/3615206/16350828/3928e530-3a2f-11e6-8bb4-6b676a77c833.png">

Now, they display as a comma-separated string:

![screen shot 2016-06-24 at 5 16 44 pm](https://cloud.githubusercontent.com/assets/3615206/16350868/75979b74-3a2f-11e6-8b19-2b4a3a9deca6.png)


This has been tested locally.  It addresses [ticket #8458](https://issues.dp.la/issues/8458).

