### PR TITLE
change facet labels from format to type

### DIFF
--- a/app/views/shared/sidebar/_refine_by_type.html.haml
+++ b/app/views/shared/sidebar/_refine_by_type.html.haml
@@ -1,7 +1,7 @@
 - if type_refines.present? or type_facets.present?
   .module.yellow
     %h6.open
-      By Format
+      By Type
       %span.icon-arrow-up{"aria-hidden" => "true"}
     .slidingDiv
       - if type_refines.present?
@@ -23,7 +23,7 @@
 // Popup
 - content_for :colorbox do
   #more_types.inline_content
-    %h1 Formats
+    %h1 Types
     - if type_facets.count > 30
       .popBar
         .pagination


### PR DESCRIPTION
This corrects the label of the type facet.  Before, it was incorrectly labeled "Format".  In all other places in the frontend application this field is referred to as "Type".  GG agrees that "Type" is the preferred label.

This has been tested locally.  It addresses [ticket #8445](https://issues.dp.la/issues/8445).