### PR TITLE
link facetable metadata value on item view

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,8 +1,23 @@
 module ItemsHelper
+
+  ##
+  # Generate an HTML list for a metadata field.
+  #
+  # @param name [String] the name of the metadata field, as defined in the Item
+  # model.
+  #
+  # @param options [Hash]
+  #   :title = Display title for the metadata field (if different from name).
+  #   :facet = Name of the field as it is used as a facet in the API. If there
+  #            is a value for :facet, the values will be linked to a faceted
+  #            search query.
+  #
+  # @return [String] HTML
   def item_field(name, options = {}, &block)
-    value = @item.send name
-    value.reject!(&:blank?) if value.is_a? Array
+    value = [@item.send(name)].flatten
+    value.reject!(&:blank?)
     title = options[:title] || name.to_s.split('_').map(&:capitalize).join(' ')
+    facet = options[:facet]
 
     if value.present?
       content_tag(:ul) do
@@ -11,10 +26,16 @@ module ItemsHelper
           content_tag(:li) do
             block.call
           end
-        elsif value.is_a? Array
-          content_tag(:li, value.join("<br />").html_safe)
         else
-          content_tag(:li, value)
+          if facet.present?
+            content_tag(:li) do
+              value.map do |v|
+                link_to v, search_path(facet => v)
+              end.join("<br/>").html_safe
+            end
+          else
+            content_tag(:li, value.join("<br />").html_safe)
+          end
         end
       end
     end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -17,8 +17,8 @@
       .table
         = item_field :creator
         = item_field :created_date
-        = item_field :provider, title: 'Partner'
-        = item_field :contributing_institution
+        = item_field :provider, title: 'Partner', facet: :partner
+        = item_field :contributing_institution, facet: :provider
         = item_field :publisher
 
       .detail-bottom
@@ -41,15 +41,10 @@
                   %span.icon-arrow-up{"aria-hidden" => "true"}
 
     .table
-      = item_field :location
+      = item_field :location, facet: :place
       = item_field :format
-      = item_field :type
-      - if @item.subject.present?
-        %ul
-          %li
-            %h6 Subject
-          %li
-            = Array(@item.subject).map { |s| link_to_subject s }.join('<br />').html_safe
+      = item_field :type, facet: :type
+      = item_field :subject, facet: :subject
       = item_field :rights
       -if @item.standardized_rights_statement.present?
         =item_field :standardized_rights_statement


### PR DESCRIPTION
This hyperlinks certain metadata field values in the `item#show` view.  If a metadata field is facetable (ie. type, partner, location), the values of these fields will link to searches with those facets applied. 

For example, in the screenshot below, you can see that the partner and contributing institution fields are hyperlinked.  If you were to click on "HathiTrust", it would take you to `/search?partner=HathiTrust`.

<img width="322" alt="screen shot 2016-06-27 at 2 14 48 pm" src="https://cloud.githubusercontent.com/assets/3615206/16390693/0d8604c2-3c72-11e6-9165-e3ec806d932f.png">

There are two exceptions: date is not linked b/c it would be a pain to deal with date ranges.  Language is not currently included on the item page, so it is also not linked (this will be addressed in ticket #8460).

The method that renders the relevant HTML snippets is `item_field`, in the items helper.   I added a param option, `:facet`, that will create the necessary link.

I refactored the `item_field` helper method a bit.  The "value" variable can be either a String or an Array.  Before, there was if-else logic to handle it either way.  Instead, to simplify things, I forced "value" to be an Array.  See `items_helper.rb` line 17.

Now that the `item_field` helper method includes the option to add hyperlinks to all metadata fields, we can use it for the "subject" field, and remove the subject-specific logic from the view and search helper.

I did not add automated tests.  Due to the current state of testing in this app, overhead would be very high.  Instead, I added detailed comments to the helper method.

This addresses [ticket #8438](https://issues.dp.la/issues/8438).  It has been tested locally.