### PR TITLE
change default search results per page to 20

### DIFF
--- a/app/helpers/result_manipulation_helper.rb
+++ b/app/helpers/result_manipulation_helper.rb
@@ -11,7 +11,11 @@ module ResultManipulationHelper
         result.push [
           size,
           url_for(params.merge(page_size: size, page: nil)),
-          size.to_s == params[:page_size] ? {selected: :selected} : {}
+          if params[:page_size].present?
+            size.to_s == params[:page_size] ? { selected: :selected } : {}
+          else
+            size.to_s == '20' ? { selected: :selected } : {}
+          end
         ]
       end
     end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -33,7 +33,9 @@ class PermittedParams < Struct.new(:params)
       when 'sort_order' then [key, value] if %w(asc desc).include?(value)
       end
     end
-    args.compact.inject({}) { |h, e| h[e.first.to_sym] = e.last; h }
+    args = args.compact.inject({}) { |h, e| h[e.first.to_sym] = e.last; h }
+    args[:page_size] = '20' unless args[:page_size].present?
+    args
   end
 
   def date_from_params(date, options = {})

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -1,13 +1,20 @@
 require 'spec_helper'
 
 describe PermittedParams do
-  describe "#search" do
-	  it "returns an array of search params" do
-	  	params = {:q=>"finch", "provider"=>["Provider 1"]}
+  describe '#search' do
+	  it 'returns an array of search params' do
+	  	params = { :q => 'finch', 'provider' => ['Provider 1'] }
 	  	@model = PermittedParams.new(params)
 	  	expect(@model.search).to match_array(
-	  		["finch",{:provider =>["Provider 1"]}]
+	  		['finch',{ :provider => ['Provider 1'] }]
 	  	)
 	  end
+  end
+
+  describe '#args' do
+    it 'defaults to page size of 20' do
+      @model = PermittedParams.new({})
+      expect(@model.args[:page_size]).to eq '20'
+    end
   end
 end


### PR DESCRIPTION
This sets the default search results per page to 20 on dp.la/search.  It changes both the API call and the default selected value in the dropdown menu.

This addresses [ticket #7754](https://issues.dp.la/issues/7754).  It has been tested locally.