### PR TITLE
add language metadata to item view

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -153,6 +153,11 @@ class Item
     @score
   end
 
+  # @return [Array<String>]
+  def language
+    Array.wrap(@sourceResource['language']).map { |l| l['name'] }.compact
+  end
+
   private
 
     def valid_http_uri?(uri)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -45,6 +45,7 @@
       = item_field :format
       = item_field :type, facet: :type
       = item_field :subject, facet: :subject
+      = item_field :language, facet: :language
       = item_field :rights
       -if @item.standardized_rights_statement.present?
         =item_field :standardized_rights_statement

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -40,4 +40,35 @@ describe Item do
       end
     end
   end
+
+  describe '#language' do
+    it 'returns language' do
+      doc = { 'sourceResource' => { 'language' => [{ 'name' => 'x' }] } }
+      item = Item.new(doc)
+      expect(item.language).to match_array ['x']
+    end
+
+    it 'handles nil value for sourceResource' do
+      item = Item.new({})
+      expect(item.language).to match_array []
+    end
+
+    it 'handles nil value for language' do
+      doc = { 'sourceResource' => {} }
+      item = Item.new(doc)
+      expect(item.language).to match_array []
+    end
+
+    it 'handles nil value for language' do
+    doc = { 'sourceResource' => { 'language' => [{}] } }
+      item = Item.new(doc)
+      expect(item.language).to match_array []
+    end
+
+    it 'handles language if Hash' do
+      doc = { 'sourceResource' => { 'language' => { 'name' => 'x' } } }
+      item = Item.new(doc)
+      expect(item.language).to match_array ['x']
+    end
+  end
 end


### PR DESCRIPTION
This adds language metadata to the item view.

Language is parsed from the API response in the `Item` model.  `language` is a property of `sourceResource`.  Here is an example of the data structure as it comes in from the API:

<img width="228" alt="screen shot 2016-06-29 at 11 39 51 am" src="https://cloud.githubusercontent.com/assets/3615206/16458793/74506850-3dee-11e6-98d8-0b7367260193.png">

The tests demonstrate the various safeguards against `nil` values and possible variances in the data structure.

This has been tested locally.  It addresses [ticket #8460](https://issues.dp.la/issues/8460).