### PR TITLE
Feature/view object link

### DIFF
--- a/app/assets/javascripts/backbone/models/timeline_item.js.coffee
+++ b/app/assets/javascripts/backbone/models/timeline_item.js.coffee
@@ -9,6 +9,8 @@ class DPLA.Models.TimelineItem extends Backbone.Model
     date = doc['sourceResource.date']
     created_date = date['displayDate'] if typeof date isnt 'undefined'
     created_date = created_date.join(', ') if _.isArray(created_date)
+    data_provider = doc['dataProvider']
+    data_provider = data_provider.join(', ') if _.isArray(data_provider)
     this.set
       id:          id
       type:        doc['sourceResource.type'] || ''
@@ -18,7 +20,8 @@ class DPLA.Models.TimelineItem extends Backbone.Model
       source:      doc['isShownAt'] || ''
       thumbnail:   doc['object']    || ''
       highlight:   false
-      created_date: created_date || ''
+      created_date:  created_date || ''
+      data_provider: data_provider || ''
 
 class DPLA.Collections.TimelineItems extends Backbone.Collection
   requestByYear: (year, options = {}) ->

--- a/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
@@ -12,7 +12,18 @@
     <p><span><%= item.created_date %></span></p>
     <p><%= item.description %></p>
     <a href="<%= item.source %>" class="ViewObject" target="_blank">
-      View Object
+      Get full
+      <% if (typeof item.type === 'string' && item.type != '') { %>
+        <%= item.type %>
+      <% } else { %>
+        item
+      <% } %>
+      from
+      <% if (item.data_provider != '') { %>
+        <%= item.data_provider %>
+      <% } else { %>
+        contributing institution
+      <% } %>
       <span class="icon-view-object" aria-hidden="true"></span>
     </a>
   </div>

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -163,6 +163,12 @@ DPLAMap = L.Class.extend
       item_title = point.title
       if $.isArray(item_title)
         item_title = item_title[0]
+      item_type = 'item'
+      if typeof point.type == 'string' and point.type != ''
+        item_type = point.type
+      item_data_provider = 'contributing institution'
+      if point.data_provider != ''
+        item_data_provider = point.data_provider
       content =
         """
           <h6> #{ point.type }</h6>
@@ -170,7 +176,10 @@ DPLAMap = L.Class.extend
           <p><span> #{ point.creator }</span></p>
           <p><span> #{ point.created_date }</span></p>
 
-          <a class="ViewObject" href="#{ point.url }" target="_blank">View Object <span class="icon-view-object" aria-hidden="true"></span></a>
+          <a class="ViewObject" href="#{ point.url }" target="_blank">
+            Get full #{ item_type } from #{ item_data_provider }
+            <span class="icon-view-object" aria-hidden="true"></span>
+          </a>
         """
       if point.thumbnail
         default_image = switch
@@ -384,6 +393,8 @@ DPLAMap = L.Class.extend
     date = doc['sourceResource.date']
     created_date = date['displayDate'] if typeof date isnt 'undefined'
     created_date = created_date.join(', ') if _.isArray(created_date)
+    data_provider = doc['dataProvider']
+    data_provider = data_provider.join(', ') if _.isArray(data_provider)
     point =
       id: doc.id
       title: doc['sourceResource.title'] || doc['id']
@@ -395,7 +406,7 @@ DPLAMap = L.Class.extend
       lat: coordinates.shift()
       lng: coordinates.shift()
       created_date: created_date || ''
-
+      data_provider: data_provider || ''
 
 DPLAPopup = L.Popup.extend
   _initLayout: ->

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -80,7 +80,7 @@ class Search
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
       sourceResource.spatial.name sourceResource.spatial.coordinates
-      sourceResource.date
+      sourceResource.date dataProvider
     )
     conditions = DPLA::Conditions.new({ q: @term }.merge(@filters).merge(fields: fields))
     "#{api_base_path}/items?#{conditions}#{api_key}"

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -16,6 +16,7 @@ class Timeline < Search
       id sourceResource.title isShownAt object
       sourceResource.type sourceResource.creator
       sourceResource.description sourceResource.date
+      dataProvider
     )
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -12,7 +12,16 @@
         = link_to @item.url, target: :_blank do
           = item_thumbnail(@item, request)
         = link_to @item.url, target: :_blank, class:'ViewObject' do
-          View Object
+          Get full
+          - if @item.type.present? and @item.type.is_a? String
+            = @item.type
+          - else
+            item
+          from
+          - if @item.data_provider.present?
+            = Array.wrap(@item.data_provider).join(', ')
+          - else
+            contributing institution
           %span.icon-view-object{"aria-hidden" => "true"}
       .table
         = item_field :creator

--- a/app/views/saved_lists/_list.html.haml
+++ b/app/views/saved_lists/_list.html.haml
@@ -38,7 +38,16 @@
             %h4= link_to position.item.title, item_path(position.item.id)
             %p= position.item.description
             = link_to position.item.url, target: :_blank, class:'ViewObject' do
-              View Object
+              Get full
+              - if position.item.type.present? and position.item.type.is_a? String
+                = position.item.type
+              - else
+                item
+              from
+              - if position.item.data_provider.present?
+                = Array.wrap(position.item.data_provider).join(', ')
+              - else
+                contributing institution
               %span.icon-view-object{"aria-hidden" => "true"}
           .searchMiddle
             = item_thumbnail(position.item, request)

--- a/app/views/saved_lists/index.html.haml
+++ b/app/views/saved_lists/index.html.haml
@@ -43,7 +43,16 @@
                       %h4= link_to position.item.title, item_path(position.item.id)
                       %p= position.item.description
                       = link_to position.item.url, target: :_blank, class:'ViewObject' do
-                        View Object
+                        Get full
+                        - if position.item.type.present? and position.item.type.is_a? String
+                          = position.item.type
+                        - else
+                          item
+                        from
+                        - if position.item.data_provider.present?
+                          = Array.wrap(position.item.data_provider).join(', ')
+                        - else
+                          contributing institution
                         %span.icon-view-object{"aria-hidden" => "true"}
                     .searchMiddle
                       = item_thumbnail(position.item, request)

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -31,7 +31,16 @@
                 %p= truncate item.description, length: 450
                 - if item.url.present?
                   = link_to item.url, class: 'ViewObject', target: :_blank do
-                    View Object
+                    Get full
+                    - if item.type.present? and item.type.is_a? String
+                      = item.type
+                    - else
+                      item
+                    from
+                    - if item.data_provider.present?
+                      = Array.wrap(item.data_provider).join(', ')
+                    - else
+                      contributing institution
                     %span.icon-view-object{"aria-hidden" => "true"}
     = render partial: 'shared/sidebar'
     #resultsBarBottom.resultsBar


### PR DESCRIPTION
This changes the text of all "View object" links in the frontend to "Get full TYPE from CONTRIBUTING INSTITUTION".  Changes are made on search, map, timeline, bookshelf, saved search, and item pages.

For example:
"Get full image from New York Public Library" 
"Get full text from Boston Public Library"
"Get full audio from The Dolph Briscoe Center for American History"

If type is missing, or there is more than one type, we will use "object", ie:
"Get full object from New Your Public Library"

If contributing institution is missing, we use "contributing institution", ie:
"Get full video from contributing institution"

Contributing institution corresponds to `dataProvider`.  Both `dataProvider` and `type` can be either Strings or Arrays.

This has been tested locally.  It addresses [ticket #8436](https://issues.dp.la/issues/8436).