### PR TITLE
reorder facets

### DIFF
--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -1,10 +1,10 @@
 %aside
   %h5 Refine search
-  = render 'shared/sidebar/refine_by_type'
+  = render 'shared/sidebar/refine_by_subject'
+  = render 'shared/sidebar/refine_by_location'
+  = render 'shared/sidebar/refine_by_language'
   = render 'shared/sidebar/refine_by_provider'
   = render 'shared/sidebar/refine_by_partner'
+  = render 'shared/sidebar/refine_by_type'
   - unless params[:controller] == 'timeline'
     = render 'shared/sidebar/refine_by_date'
-  = render 'shared/sidebar/refine_by_language'
-  = render 'shared/sidebar/refine_by_location'
-  = render 'shared/sidebar/refine_by_subject'

--- a/app/views/shared/sidebar/_refine_by_date.html.haml
+++ b/app/views/shared/sidebar/_refine_by_date.html.haml
@@ -1,6 +1,6 @@
 .module.yellow
   %h6.open
-    By Date
+    Date
     %span.icon-arrow-up{"aria-hidden" => "true"}
   .slidingDiv
     - if after_refine.present?

--- a/app/views/shared/sidebar/_refine_by_language.html.haml
+++ b/app/views/shared/sidebar/_refine_by_language.html.haml
@@ -1,7 +1,7 @@
 - if language_refines.present? or language_facets.present?
   .module.yellow
     %h6.open
-      By Language
+      Language
       %span.icon-arrow-up{"aria-hidden" => "true"}
     .slidingDiv
       - if language_refines.present?

--- a/app/views/shared/sidebar/_refine_by_location.html.haml
+++ b/app/views/shared/sidebar/_refine_by_location.html.haml
@@ -1,7 +1,7 @@
 - if country_refines.present? or state_refines.present? or place_refines.present? or place_facets.present?
   .module.yellow
     %h6.open
-      By Location
+      Location
       %span.icon-arrow-up{"aria-hidden" => "true"}
     .slidingDiv
       - if country_refines.present?

--- a/app/views/shared/sidebar/_refine_by_subject.html.haml
+++ b/app/views/shared/sidebar/_refine_by_subject.html.haml
@@ -1,10 +1,9 @@
 - if subject_refines.present? or subject_facets.present?
-  - is_collapsed = params[:q].blank? && subject_refines.blank?
   .module.yellow.subject
     %h6.open
-      By Subject
-      %span{'aria-hidden' => "true", class: is_collapsed ? 'icon-arrow-down' : 'icon-arrow-up'}
-    .slidingDiv{style: is_collapsed ? 'display:none;' : ''}
+      Subject
+      %span.icon-arrow-up{"aria-hidden" => "true"}
+    .slidingDiv
       - if subject_refines.present?
         - subject_refines.each do |refine|
           .refineResult

--- a/app/views/shared/sidebar/_refine_by_type.html.haml
+++ b/app/views/shared/sidebar/_refine_by_type.html.haml
@@ -1,7 +1,7 @@
 - if type_refines.present? or type_facets.present?
   .module.yellow
     %h6.open
-      By Type
+      Type
       %span.icon-arrow-up{"aria-hidden" => "true"}
     .slidingDiv
       - if type_refines.present?


### PR DESCRIPTION
This changes the order in which facets are displayed in the search, map, timeline, and bookshelf interfaces.  The new facet order was determined in consultation with MLB, MM, and DC after reviewing analytics data.

This also changes the subject facet so that it is, by default, expanded - previously, it was, by default, collapsed.  All other facets are expanded by default.

Finally, this removed the word "By" from facet titles for consistency - previously, some facets titles started with "By" and others did not.

This addresses [ticket #7753](https://issues.dp.la/issues/7753).  It has been tested locally.