### PR TITLE
Increase num of facets in popups. Include provider in results count.

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -92,7 +92,7 @@ class Search
 
   def conditions
     facets = %w(subject language type provider partner country state place)
-    { q: @term, facets: facets, facet_size: 150 }.merge(@filters).merge(@args)
+    { q: @term, facets: facets, facet_size: 2000 }.merge(@filters).merge(@args)
   end
 
   private

--- a/app/views/shared/results/_search_results.html.haml
+++ b/app/views/shared/results/_search_results.html.haml
@@ -8,12 +8,23 @@
         %span= query
       returned
       = number_with_delimiter search.count, delimiter: ','
+      - if search.count > 1
+        results
+      - else
+        result
       - if 'map' == params[:controller]
-        results with location coordinates.
+        with location coordinates
       - elsif 'timeline' == params[:controller]
-        results with dates.
-      -else
-        results.
+        with dates
+      - if provider_facets.present?
+        from
+        = "#{ 'over' if provider_facets.count >= 2000 }"
+        = "#{ number_with_delimiter provider_facets.count, delimiter: ',' }"
+        contributing
+        - if provider_facets.count > 1
+          institutions
+        - else
+          institution
       = render 'shared/results/refined_by', search: search
 - else
   .searchResults.no-results#content{role: "main"}

--- a/app/views/shared/sidebar/_refine_by_language.html.haml
+++ b/app/views/shared/sidebar/_refine_by_language.html.haml
@@ -29,7 +29,7 @@
       .popBar
         .pagination
           .t-data-grid-pager
-            - pages = (language_facets.count.to_f / 30).ceil
+            - pages = [(language_facets.count.to_f / 30).ceil, 10].min
             - (1..pages).to_a.each do |page|
               - if page == 1
                 %span.current{data: {page: page}}= page

--- a/app/views/shared/sidebar/_refine_by_location.html.haml
+++ b/app/views/shared/sidebar/_refine_by_location.html.haml
@@ -53,7 +53,7 @@
           .pagination
             .t-data-grid-pager
               - if country_facets.count > 30
-                - pages = (country_facets.count.to_f / 30).ceil
+                - pages = [(country_facets.count.to_f / 30).ceil, 10].min
                 - (1..pages).to_a.each do |page|
                   - if page == 1
                     %span.current{data: {page: page}}= page
@@ -106,7 +106,7 @@
           .pagination
             .t-data-grid-pager
               - if state_facets.count > 30
-                - pages = (state_facets.count.to_f / 30).ceil
+                - pages = [(state_facets.count.to_f / 30).ceil, 10].min
                 - (1..pages).to_a.each do |page|
                   - if page == 1
                     %span.current{data: {page: page}}= page
@@ -131,7 +131,7 @@
         .pagination
           .t-data-grid-pager
             - if place_facets.count > 30
-              - pages = (place_facets.count.to_f / 30).ceil
+              - pages = [(place_facets.count.to_f / 30).ceil, 10].min
               - (1..pages).to_a.each do |page|
                 - if page == 1
                   %span.current{data: {page: page}}= page
@@ -157,7 +157,7 @@
         .pagination
           .t-data-grid-pager
             - if place_facets.count > 30
-              - pages = (place_facets.count.to_f / 30).ceil
+              - pages = [(place_facets.count.to_f / 30).ceil, 10].min
               - (1..pages).to_a.each do |page|
                 - if page == 1
                   %span.current{data: {page: page}}= page

--- a/app/views/shared/sidebar/_refine_by_partner.html.haml
+++ b/app/views/shared/sidebar/_refine_by_partner.html.haml
@@ -28,7 +28,7 @@
       .popBar
         .pagination
           .t-data-grid-pager
-            - pages = (partner_facets.count.to_f / 30).ceil
+            - pages = [(partner_facets.count.to_f / 30).ceil, 10].min
             - (1..pages).to_a.each do |page|
               - if page == 1
                 %span.current{data: {page: page}}= page

--- a/app/views/shared/sidebar/_refine_by_provider.html.haml
+++ b/app/views/shared/sidebar/_refine_by_provider.html.haml
@@ -28,7 +28,7 @@
       .popBar
         .pagination
           .t-data-grid-pager
-            - pages = (provider_facets.count.to_f / 30).ceil
+            - pages = [(provider_facets.count.to_f / 30).ceil, 10].min
             - (1..pages).to_a.each do |page|
               - if page == 1
                 %span.current{data: {page: page}}= page

--- a/app/views/shared/sidebar/_refine_by_subject.html.haml
+++ b/app/views/shared/sidebar/_refine_by_subject.html.haml
@@ -29,7 +29,7 @@
       .popBar
         .pagination
           .t-data-grid-pager
-            - pages = (subject_facets.count.to_f / 30).ceil
+            - pages = [(subject_facets.count.to_f / 30).ceil, 10].min
             - (1..pages).to_a.each do |page|
               - if page == 1
                 %span.current{data: {page: page}}= page


### PR DESCRIPTION
This PR addresses two related issues.

The first issue is including a message to the user of how many contributing institutions are represented in their search results.  Currently, the message a the top of the search results page says something like: "Your search returned 1,234 results."  The desired functionality is for the message to say something like:  "Your search returned 1,234 results from 56 contributing institutions."

The challenge here is that there is currently no way to get the total number of contributing institutions from the API.  The best we can do is total the contributing institutions facet, which is capped at 2,000.  No problem... unless a search result includes more than 2,000 contributing institutions!  The work-around MLB and I landed on is this: If there are less than 2,000 contributing institutions in the facet, we report the actual number.  If there are 2,000 contributing institutions in the facet, we report "Your search returned 1,234 results from over 2,000 contributing institutions".  There is a tiny inaccuracy there in that if there are EXACTLY 2,000 institutions, we will say there are "over 2,000", but I think we can live with that.

In order to implement this, we had to change the `facet_size` in the API request from 150 to 2,000 (2,000 is the maximum imposed by the API).  I hope that requesting so much more data will not cause any performance issues, but please let me know if you think it's cause for concern.

The second related issue is the number of additional facet values that appear in the filter popups when a user clicks "more".  Here's an example from the current production deployment:

<img width="1048" alt="screen shot 2016-06-30 at 2 20 54 pm" src="https://cloud.githubusercontent.com/assets/3615206/16499349/0548720a-3ece-11e6-832b-8aa1e650822a.png">

We wanted to increase the number of facets that appeared.  Which we can do now, b/c we're getting 2,000 facets!  2,000 is too many through - that would be 67 pages in the popup window - so we capped it at 10 pages.

This has been tested locally.  It addresses [ticket #8437](https://issues.dp.la/issues/8437) and [ticket #6311](https://issues.dp.la/issues/6311).