### PR TITLE
realign metadata elements

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -929,7 +929,7 @@ article .shareSave { margin: 0 0 3% 74.286%; }
     overflow: hidden;
     padding: 10px 0 0;
 }
-.FeatureContent .table { padding-left: 29%; }
+.FeatureContent .table { overflow: hidden; }
 .table ul:first-child {
     border: none;
     padding: 0;
@@ -1203,7 +1203,7 @@ h6.open span {
 
 .desc-short, .desc-long { overflow: hidden; }
 .desc-long { display: none; }
-.desc-toggle { text-decoration: none !important; }
+.desc-toggle { text-decoration: none !important; display: block; }
 .desc-toggle:hover { cursor: pointer; }
 .desc-toggle span { font-size: .5em; }
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -21,36 +21,35 @@
         = item_field :contributing_institution, facet: :provider
         = item_field :publisher
 
-      .detail-bottom
         - if @item.description.present?
-          %h6 Description
-          .desc-short
-            %p
-              = truncate @item.description, length: 450
+          %ul
+            %li
+              %h6 Description
+            %li
+              .desc-short
+                = truncate @item.description, length: 450
+                - if @item.description.length > 450
+                  %a.desc-toggle
+                    more
+                    %span.icon-arrow-down{"aria-hidden" => "true"}
               - if @item.description.length > 450
-                %a.desc-toggle
-                  more
-                  %span.icon-arrow-down{"aria-hidden" => "true"}
-          - if @item.description.length > 450
-            .desc-long
-              %p
-                = @item.description
-                &nbsp;
-                %a.desc-toggle
-                  less
-                  %span.icon-arrow-up{"aria-hidden" => "true"}
+                .desc-long
+                  = @item.description
+                  %a.desc-toggle
+                    less
+                    %span.icon-arrow-up{"aria-hidden" => "true"}
 
-    .table
-      = item_field :location, facet: :place
-      = item_field :format
-      = item_field :type, facet: :type
-      = item_field :subject, facet: :subject
-      = item_field :language, facet: :language
-      = item_field :rights
-      -if @item.standardized_rights_statement.present?
-        =item_field :standardized_rights_statement
-      = item_field :url, title: 'URL' do
-        = link_to @item.url, @item.url, target: :_blank
+        = item_field :location, facet: :place
+        = item_field :format
+        = item_field :type, facet: :type
+        = item_field :subject, facet: :subject
+        = item_field :language, facet: :language
+        = item_field :rights
+        -if @item.standardized_rights_statement.present?
+          =item_field :standardized_rights_statement
+        = item_field :url, title: 'URL' do
+          = link_to @item.url, @item.url, target: :_blank
+
   %aside
     - # is_location_present = @item.location.present? && @item.coordinates.present?
     - is_date_present     = @item.created_date.present? && @item.year.present?


### PR DESCRIPTION
This aligns metadata fields on /item pages to make them easier to read/scan.  It left-aligns all metadata elements, instead of letting them wrap under the thumbnail image.  It also makes the the "Description" field conform stylistically with the other fields.  Before, "Description" had its own style, which disrupted the flow of the page.

Before:

![screen shot 2016-06-30 at 3 41 49 pm](https://cloud.githubusercontent.com/assets/3615206/16501816/4b5b2fe8-3ed9-11e6-89a2-c87bad72c364.png)


After:

![screen shot 2016-06-30 at 3 42 07 pm](https://cloud.githubusercontent.com/assets/3615206/16501811/47b86158-3ed9-11e6-8f0a-52fd2d93d036.png)


Out of scope for this PR is the issue where on small screens, labels such as "Contributing Institution" squish into the text to the immediate right.  That is addressed in another ticket.

This has been tested locally and on staging.  It addresses [ticket #7827](https://issues.dp.la/issues/7827).