### PR TITLE
change label width

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -938,13 +938,13 @@ article .shareSave { margin: 0 0 3% 74.286%; }
 .table li {
     float: left;
     list-style: none outside none;
-    width: 76.9%;
+    width: 70%;
 	margin: 0 0 5px;
 	line-height: 1.2em;
 }
 
 .table li:first-child {
-    width: 21.9%;
+    width: 28.8%;
     margin: 0 1.2% 0 0;
 }
 .table li a {


### PR DESCRIPTION
This fixes there problem whereby on /item pages in certain mobile views, the "Contributing Institution" label was overlapping with the adjacent text.  

Before:

<img width="204" alt="screen shot 2016-06-30 at 5 48 37 pm" src="https://cloud.githubusercontent.com/assets/3615206/16505438/f6f3492e-3eea-11e6-802f-e642cf46fa57.png">

After:

<img width="225" alt="screen shot 2016-06-30 at 5 48 17 pm" src="https://cloud.githubusercontent.com/assets/3615206/16505432/f3336224-3eea-11e6-86c5-952c2f750139.png">

This has been tested locally using the Chrome Device Mode developer tool.  It addresses [ticket #6533](https://issues.dp.la/issues/6533).
