### PR TITLE
show actual totals for map and timeline

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -2,7 +2,12 @@ class MapController < ApplicationController
   helper_method :permitted_params
 
   def show
-    @search = Map.new permitted_params.term, permitted_params.filters
+    # Get items that match current search terms and filters, and that have
+    # spatial coordinates.
+    @search = Map.new permitted_params.term,
+                      permitted_params.filters,
+                      { page_size: 0,
+                        'sourceResource.spatial.coordinates' => '90,-179.99:-90,180' }
   end
 
   private

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -2,8 +2,14 @@ class TimelineController < ApplicationController
   helper_method :permitted_params
 
   def show
-    @search = Search.new permitted_params.term, permitted_params.filters(ignore_dates: true), {page_size: 0}
-    @timeline = Timeline.new permitted_params.term, permitted_params.filters(ignore_dates: true)
+    # Get items that match current search terms and filters, and that have dates
+    # starting at the year 1000.
+    @search = Search.new permitted_params.term,
+                         permitted_params.filters(ignore_dates: true),
+                         { page_size: 0, 'sourceResource.date.after' => '1000' }
+    @timeline = Timeline.new permitted_params.term,
+                             permitted_params.filters(ignore_dates: true),
+                             { 'sourceResource.date.after' => '1000' }
   end
 
   private

--- a/app/views/shared/results/_search_results.html.haml
+++ b/app/views/shared/results/_search_results.html.haml
@@ -9,9 +9,9 @@
       returned
       = number_with_delimiter search.count, delimiter: ','
       - if 'map' == params[:controller]
-        results. Only results with location data are shown below.
+        results with location coordinates.
       - elsif 'timeline' == params[:controller]
-        results. Only results with time data are shown below.
+        results with dates.
       -else
         results.
       = render 'shared/results/refined_by', search: search


### PR DESCRIPTION
This fixes the count of total search results and the facets on map and timeline to match the results displayed in the map and timeline interfaces.

The map only displays items that have a value for `sourceResource.spatial.coordinates`.  The timeline only displays those that have a value for `sourceResource.date`.  However, before this PR, the API query that was used to generate the total search results and the facet filters returned all results, regardless of whether or not they had coordinates or dates.  This caused the results total and the facet filters to show more results than were actually present on the map or timeline.  Here is an example of this behavior on production: https://dp.la/map?utf8=%E2%9C%93&q=fish+taco  Note that the total and facets suggest there are three results, but none of them are actually displaying on the map b/c they do not have coordinate data.

This PR changes the API requests that are used to generate results total and facet filters, forcing them to return only items that have dates or coordinates.  Since there is no way of directly asking the API to return only items that have a value for a specific field, the queries instead ask for a coordinate range that encompasses the whole Earth, or a date range that encompasses the whole timeline (note that the timeline begins at year 1000).

This has been tested locally.  It addresses [ticket #8439](https://issues.dp.la/issues/8439).