### PR TITLE
enclose timeline paths in double quotes

### DIFF
--- a/app/views/timeline/show.html.haml
+++ b/app/views/timeline/show.html.haml
@@ -38,7 +38,7 @@
     = render 'shared/sidebar'
 
 :javascript
-  window.api_search_path    = '#{@timeline.api_search_path}';
-  window.api_item_path      = '#{@timeline.api_item_path}';
+  window.api_search_path    = "#{@timeline.api_search_path}";
+  window.api_item_path      = "#{@timeline.api_item_path}";
   window.default_img_path   = '#{asset_path('icon-text.gif')}';
   window.finalYear          = '#{@timeline.final_year}'


### PR DESCRIPTION
This fixes a bug in the timeline in which searches that include apostrophes were failing to generate a "Year" view.  

For instance: http://dp.la/timeline?q=%22valentine%27s+day%22&utf8=%E2%9C%93#/1905

Enclosing the search path in double quotes fixes the issue.  I also enclosed the item path, which is not currently an issue, but could be if we ever switch to using item URLs with keywords.

This has been tested locally. It addresses [ticket #7776](https://issues.dp.la/issues/7776).