### PR TITLE
enclose map paths in double quotes

### DIFF
--- a/app/views/map/show.html.haml
+++ b/app/views/map/show.html.haml
@@ -24,7 +24,7 @@
 
 :javascript
   window.states   = #{@search.geocoded_states.to_json};
-  window.api_search_path = '#{@search.api_search_path}';
+  window.api_search_path = "#{@search.api_search_path}";
   window.app_search_path = '#{@search.app_search_path}';
   window.config = #{Settings.ui.maps.to_json};
   window.default_images = {


### PR DESCRIPTION
This fixes a bug in map where the map fails to render if the search term includes an apostrophe.

This has been tested locally.  It addresses [ticket #6388](https://issues.dp.la/issues/6388).