### PR TITLE
change discontinue message on bookshelf view

### DIFF
--- a/app/views/bookshelf/show.html.haml
+++ b/app/views/bookshelf/show.html.haml
@@ -9,3 +9,5 @@
     or
     %a{:href => '/timeline/'}timeline
     to find content in the DPLA.  We're sorry for any inconvenience.
+    Stay tuned to learn how DPLA is
+    %a{:href => '/get-involved/dpla-ebooks'}improving access to ebooks.


### PR DESCRIPTION
This changes the message on the bookshelf view to include a link to info about DPLA ebooks, as per MLB's request.

This has been tested locally.  It addresses [ticket #8435](https://issues.dp.la/issues/8435).