### PR TITLE
fix view object link to accept single array value for type

### DIFF
--- a/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
@@ -15,6 +15,8 @@
       Get full
       <% if (typeof item.type === 'string' && item.type != '') { %>
         <%= item.type %>
+      <% } else if (_.isArray(item.type) && item.type.length == 1) { %>
+        <%= item.type[0] %>
       <% } else { %>
         item
       <% } %>

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -166,6 +166,8 @@ DPLAMap = L.Class.extend
       item_type = 'item'
       if typeof point.type == 'string' and point.type != ''
         item_type = point.type
+      if $.isArray(point.type) && point.type.length == 1
+        item_type = point.type[0]
       item_data_provider = 'contributing institution'
       if point.data_provider != ''
         item_data_provider = point.data_provider

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,22 @@ module ApplicationHelper
       image_name
     end
   end
+
+  def view_object_link(item)
+    return unless item.url.present?
+
+    type = Array.wrap(item.type)
+    data_provider = Array.wrap(item.data_provider)
+
+    type_name = 'item'
+    type_name = type.last if type.count == 1
+
+    ci_name = 'contributing institution'
+    ci_name = data_provider.join(', ') if data_provider.present?
+
+    link = link_to item.url, target: :_blank, class: 'ViewObject' do
+      "Get full #{type_name} from #{ci_name}" \
+      '<span class="icon-view-object" aria-hidden="true"></span>'.html_safe
+    end
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,18 +11,7 @@
       .contentBox
         = link_to @item.url, target: :_blank do
           = item_thumbnail(@item, request)
-        = link_to @item.url, target: :_blank, class:'ViewObject' do
-          Get full
-          - if @item.type.present? and @item.type.is_a? String
-            = @item.type
-          - else
-            item
-          from
-          - if @item.data_provider.present?
-            = Array.wrap(@item.data_provider).join(', ')
-          - else
-            contributing institution
-          %span.icon-view-object{"aria-hidden" => "true"}
+        = view_object_link(@item)
       .table
         = item_field :creator
         = item_field :created_date

--- a/app/views/saved_lists/_list.html.haml
+++ b/app/views/saved_lists/_list.html.haml
@@ -37,18 +37,7 @@
           .searchLeft
             %h4= link_to position.item.title, item_path(position.item.id)
             %p= position.item.description
-            = link_to position.item.url, target: :_blank, class:'ViewObject' do
-              Get full
-              - if position.item.type.present? and position.item.type.is_a? String
-                = position.item.type
-              - else
-                item
-              from
-              - if position.item.data_provider.present?
-                = Array.wrap(position.item.data_provider).join(', ')
-              - else
-                contributing institution
-              %span.icon-view-object{"aria-hidden" => "true"}
+            = view_object_link(position.item)
           .searchMiddle
             = item_thumbnail(position.item, request)
           -if @is_my_list

--- a/app/views/saved_lists/index.html.haml
+++ b/app/views/saved_lists/index.html.haml
@@ -42,18 +42,7 @@
                     .searchLeft
                       %h4= link_to position.item.title, item_path(position.item.id)
                       %p= position.item.description
-                      = link_to position.item.url, target: :_blank, class:'ViewObject' do
-                        Get full
-                        - if position.item.type.present? and position.item.type.is_a? String
-                          = position.item.type
-                        - else
-                          item
-                        from
-                        - if position.item.data_provider.present?
-                          = Array.wrap(position.item.data_provider).join(', ')
-                        - else
-                          contributing institution
-                        %span.icon-view-object{"aria-hidden" => "true"}
+                      = view_object_link(position.item)
                     .searchMiddle
                       = item_thumbnail(position.item, request)
                     .searchRight

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -29,19 +29,7 @@
                 %p
                   %span= item.created_date.join(', ')
                 %p= truncate item.description, length: 450
-                - if item.url.present?
-                  = link_to item.url, class: 'ViewObject', target: :_blank do
-                    Get full
-                    - if item.type.present? and item.type.is_a? String
-                      = item.type
-                    - else
-                      item
-                    from
-                    - if item.data_provider.present?
-                      = Array.wrap(item.data_provider).join(', ')
-                    - else
-                      contributing institution
-                    %span.icon-view-object{"aria-hidden" => "true"}
+                = view_object_link(item)
     = render partial: 'shared/sidebar'
     #resultsBarBottom.resultsBar
       = render partial: 'paginator'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+
+  describe '#view_object_link' do
+    let(:item) { double }
+    before do
+      allow(item).to receive(:type)
+      allow(item).to receive(:data_provider)
+    end
+
+    it 'returns nil without a url' do
+      allow(item).to receive(:url).and_return nil
+      expect(helper.view_object_link(item)).to be nil
+    end
+
+    context 'with url' do
+      before { allow(item).to receive(:url).and_return 'example.org' }
+
+      it 'returns an HTML link' do
+        expect(helper.view_object_link(item)).to start_with('<a')
+        expect(helper.view_object_link(item)).to end_with('</a>')
+      end
+
+      it 'provides default values' do
+        expect(helper.view_object_link(item))
+          .to include('item', 'contributing institution')
+      end
+
+      it 'includes type if String' do
+        allow(item).to receive(:type).and_return 'moving image'
+        expect(helper.view_object_link(item)).to include('moving image')
+      end
+
+      it 'includes type if single value in Array' do
+        allow(item).to receive(:type).and_return ['moving image']
+        expect(helper.view_object_link(item)).to include('moving image')
+      end
+
+      it 'does not include type if multi-value in Array' do
+        allow(item).to receive(:type).and_return ['type_a', 'type_b']
+        expect(helper.view_object_link(item)).not_to include('type_a', 'type_b')
+      end
+
+      it 'includes data provider if String' do
+        allow(item).to receive(:data_provider).and_return 'Coralville Library'
+        expect(helper.view_object_link(item)).to include('Coralville Library')
+      end
+
+      it 'includes data provider if Array' do
+        allow(item).to receive(:data_provider).and_return ['Winnie', 'Peaches']
+        expect(helper.view_object_link(item)).to include('Winnie, Peaches')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes the new wording of the "View object" links ([PR#97](https://github.com/dpla/frontend/pull/97)).  The bug was discovered on staging, and was _not_ deployed to production.  

With these changes, the value of `sourceResource.type` will display in the link if it is a single-value Array (before, it was not displaying).  I also took the opportunity to abstract out the ruby-language code to a helper method and write a series of tests.

This has been tested locally and on staging.  It addresses [ticket #8436](https://issues.dp.la/issues/8436).