### PR TITLE
fix typo in ebooks URL

### DIFF
--- a/app/views/bookshelf/show.html.haml
+++ b/app/views/bookshelf/show.html.haml
@@ -10,4 +10,4 @@
     %a{:href => '/timeline/'}timeline
     to find content in the DPLA.  We're sorry for any inconvenience.
     Stay tuned to learn how DPLA is
-    %a{:href => '/get-involved/dpla-ebooks'}improving access to ebooks.
+    %a{:href => '/info/get-involved/dpla-ebooks'}improving access to ebooks.


### PR DESCRIPTION
Fix a typo in the ebooks URL on bookshelf.