### PR TITLE
add icon labels

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -770,24 +770,25 @@ aside .module span { color: #000; }
 
 .searchViews {
     float: left;
-    margin: 23px 0 0;
+    margin: 13px 0 0;
     width: 28%;
 }
 .searchViews span {
     float: left;
     color: #fff;
-    margin: 0 9% 0 0;
+    margin: 0;
 }
 .searchViews ul {
     float: left;
     margin: 0;
     padding: 0;
+    width: 100%;
 }
-.searchViews li:first-child { margin: 0; }
 .searchViews li {
     float: left;
     list-style: none outside none;
-    margin: 0 0 0 12px;
+    margin: 0;
+    width: 33%;
 }
 .searchViews li span { color: #ccc; }
 .searchViews li.active span, .searchViews li:hover span {
@@ -799,24 +800,30 @@ aside .module span { color: #000; }
     transition: 0.3s ease;
 }
 .searchViews li.active span { cursor: text; }
+
 .searchViews a {
     display: block;
-    height: 17px;
-    width: 23px;
+    height: 46px;
+    position: relative;
 }
-
-.searchViews a.viewTwo {
-    height: 26px;
-    width: 14px;
-    margin-top: -4px;
+.searchViews a span {
+    position: absolute;
 }
-.searchViews a.viewThree {
-    height: 20px;
-    margin-top: -1px;
+.searchViews a span.icon-view-list {
+    left: 1px;
+    top: 4px;
 }
-.searchViews a.viewFour {
-    height: 20px;
-    margin-top: -3px;
+.searchViews a.viewTwo span.icon-view-map {
+    top: 0px;
+    left: 7px;
+}
+.searchViews a.viewThree span.icon-view-time {
+    top: 3px;
+    left: 11px;
+}
+.searchViews a span.icon-label {
+    left: 0;
+    bottom: 0;
 }
 
 .exibition-image {
@@ -3923,7 +3930,6 @@ body .container .upper-left h2 { font-size: 1.4em; }
 
 .searchViews {
     width: 56%;
-    margin-top: 23px;
 }
 .matches h4 {
     margin-bottom: 6px;

--- a/app/views/shared/_search_panel.html.haml
+++ b/app/views/shared/_search_panel.html.haml
@@ -5,20 +5,19 @@
   .searchRowRight
     - if %w(timeline search map).include? params[:controller]
       .searchViews
-        %span View:
         %ul
           %li{class: params[:controller] == 'search' && 'active'}
             = link_to search_path(params.except(:controller, :action)) do
               %span.icon-view-list{"aria-hidden" => "true", :title => "List"}
-              %span.visuallyhidden List
+              %span.icon-label List
           %li{class: params[:controller] == 'map' && 'active'}
             = link_to map_path(params.except(:controller, :action)), class: 'viewTwo' do
               %span.icon-view-map{"aria-hidden" => "true", :title => "Map"}
-              %span.visuallyhidden Map
+              %span.icon-label Map
           %li{class: params[:controller] == 'timeline' && 'active'}
             = link_to timeline_path(params.except(:controller, :action)), class: 'viewThree' do
               %span.icon-view-time{"aria-hidden" => "true", :title => "Timeline"}
-              %span.visuallyhidden Timeline
+              %span.icon-label Timeline
     %a.search-btn{:href => ""}
       %span.icon-mag-glass{"aria-hidden" => "true"}
       %span.visuallyhidden Search


### PR DESCRIPTION
This adds labels under the icons for List, Map, and Timeline in order to make them easier for users to understand.  Tweaks to the CSS make the layout look nice with the labels.

Before:
<img width="647" alt="screen shot 2016-07-08 at 10 45 23 am" src="https://cloud.githubusercontent.com/assets/3615206/16691082/1a328ea4-44f9-11e6-911f-7f72f2b6a663.png">

After:
<img width="642" alt="screen shot 2016-07-08 at 10 44 43 am" src="https://cloud.githubusercontent.com/assets/3615206/16691070/06bd1ccc-44f9-11e6-9094-d17f108ca3df.png">

This has been tested locally, on staging, and with the Chrome device tool for mobile.  It addresses [ticket #7725](https://issues.dp.la/issues/7752).  