### PR TITLE
increase apps per page to 60

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -3,7 +3,7 @@ class AppsController < ApplicationController
   before_filter :authenticate_admin!, except: [:index, :show]
 
   def index
-    @apps = App.page(params[:page]).per(12)
+    @apps = App.page(params[:page]).per(60)
 
     respond_to do |format|
       format.html # index.html.erb


### PR DESCRIPTION
This increases the number of apps we show per page from 12 to 60 on dp.la/apps.  We currently have 32 apps, and don't add them very rapidly.  This will eliminate the need for pagination, at least for the near future, exposing users to our full app abundance on one delightful page.

This addresses [ticket #7760].  It has been tested on staging.