### PR TITLE
Consistent header display across mobile search interfaces

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -1444,7 +1444,6 @@ aside .moduleSection p { margin: 0 0 10px; }
 
 .timeline .toggle {
     display: inline-block;
-    margin: 6px 0 10px;
 }
 .timeline aside {
     height: 100%;
@@ -2035,7 +2034,7 @@ input[type="checkbox"] {
     cursor: pointer;
     display: none;
     font-size: 16px;
-    margin: 0 0 20px;
+    margin: 6px 0 18px 0;
     padding: 7px 12px;
     width: auto;
 }
@@ -4114,7 +4113,6 @@ body .container .upper-left h2 { font-size: 1.4em; }
     width: 30%;
 }
 .search-page aside { margin: 0; }
-.search-page h1 { position: absolute; left: -999em; }
 .collection-detail h1 {
     position: static;}
 .searchRow { margin: 0 0 7px; }
@@ -4212,8 +4210,7 @@ aside { height: 100%; }
 .map iframe { height: 200px; }
 .mapContainer { position: relative; }
 .mobile-hover { height: 100%; position: absolute; width: 100%; z-index: 2; }
-.map .searchRow { margin: 0 0 5%; }
-.map .toggle { margin: 4% 0 5%; display: none; }
+.map .toggle { display: none; }
 .map .toggle.mobile { display: inline-block; }
 .map .toggle.Maside { display: none; }
 .map .pagination { width: 100%; }

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -4,10 +4,11 @@
 .layoutTwo.search-page
   = render 'shared/search_panel'
   = render 'shared/share_save'
-  = render 'shared/aside_toggle'
   %h1 Search Results
   = render 'shared/results/search_results', query: params[:q], search: @search
   - if @search.count > 0
+    = render 'shared/aside_toggle'
+
     .slidePopOut#content{role: "main"}
       #resultsBarTop.resultsBar
         = render partial: 'paginator'


### PR DESCRIPTION
This fixes design inconsistencies in the headers on /search, /map, and /timeline.  With this PR:
- `h1` text appears on all views
- Refine button appears in the same place
- White space surrounding `h1` and refine buttons are consistent

Before:

<img width="220" alt="screen shot 2016-07-08 at 3 00 27 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698600/1fccc018-451d-11e6-9820-3a121e7c5d2f.png">

<img width="222" alt="screen shot 2016-07-08 at 3 00 07 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698604/257757d0-451d-11e6-9d27-1523916fdff4.png">

<img width="222" alt="screen shot 2016-07-08 at 3 00 17 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698607/28f1e768-451d-11e6-9129-2df506c50129.png">


After:

<img width="222" alt="screen shot 2016-07-08 at 2 58 47 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698612/2cf0a3c2-451d-11e6-8381-56681b0a7640.png">

<img width="221" alt="screen shot 2016-07-08 at 2 58 17 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698615/2fe158ec-451d-11e6-9124-0a9626902b46.png">

<img width="223" alt="screen shot 2016-07-08 at 2 58 36 pm" src="https://cloud.githubusercontent.com/assets/3615206/16698616/323429ee-451d-11e6-97ba-ac940cf92e2c.png">

This has been tested locally using Chrome Device Mode.  It addresses [ticket #7825](https://issues.dp.la/issues/7825).