### PR TITLE
direct link from slideshow images

### DIFF
--- a/app/assets/javascripts/vendor/main.js
+++ b/app/assets/javascripts/vendor/main.js
@@ -28,7 +28,7 @@ if ($('.shareSave').length) {
       nextText: '<span class="icon-arrow-right" aria-hidden="true"></span>'
 	});
 
-	$('.moreInfo').mouseover(function () {
+	$('.homeslide').mouseenter(function () {
       $(this).addClass('hover');
       $('.flex-direction-nav a').addClass('hover');
 	    $('.flex-active-slide .slideOverlay').addClass('on');
@@ -42,31 +42,27 @@ if ($('.shareSave').length) {
 		return false;
 	});
 
-  $('.moreInfo').toggle(function() {
-      $(this).addClass('hover');
-      $('.flex-direction-nav a').addClass('hover');
-      $('.flex-active-slide .slideOverlay').addClass('on');
-      $('.flex-active-slide .slideText').addClass('on');
-    },
-    function() {
-      $(this).removeClass('hover');
-      $('.flex-direction-nav a').removeClass('hover');
-      $('.flex-active-slide .slideOverlay').removeClass('on');
-      $('.flex-active-slide .slideText').removeClass('on');
-    }
-  );
-
 	$('.homeslide').mouseleave(function () {
 	    $('.slideOverlay').removeClass('on');
 	    $('.slideText').removeClass('on');
-      $('.moreInfo').removeClass('hover');
       $('.flex-direction-nav a').removeClass('hover');
 	 });
 
+  $('.flex-direction-nav a').mouseover(function () {
+      $('.slideOverlay').removeClass('on');
+      $('.slideText').removeClass('on');
+  });
+
+  $('.flex-direction-nav a').mouseleave(function () {
+      $('.homeslide').addClass('hover');
+      $('.flex-direction-nav a').addClass('hover');
+      $('.flex-active-slide .slideOverlay').addClass('on');
+      $('.flex-active-slide .slideText').addClass('on');
+  });
+
 	$('.flex-direction-nav a').click(function () {
-	    $('.slideOverlay').removeClass('on');
-	    $('.slideText').removeClass('on');
-      $('.moreInfo').removeClass('hover');
+      $('.slideOverlay').removeClass('on');
+    $('.slideText').removeClass('on');
       $('.flex-direction-nav a').removeClass('hover');
 	});
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -8,49 +8,54 @@
         .flexslider.homeslide
           %ul.slides
             %li
-              = image_tag "slide/home-slide-pss.jpg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/primary-source-sets'} Check out the DPLA's new Primary Source Sets for Education&nbsp;»
+              %a{:href => '/primary-source-sets'}
+                = image_tag "slide/home-slide-pss.jpg"
+                .slideOverlay
+                .slideText
+                  %p
+                    Check out the DPLA's new Primary Source Sets for Education&nbsp;»
             %li
-              = image_tag "slide/home-slide7.png"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/92028cc0c0064c6690a39a6d67b11fde'} Americae Sive Novi Orbis Nova Descriptio, 1587. Ortelius Abraham, cartographer&nbsp;»
+              %a{:href => '/item/92028cc0c0064c6690a39a6d67b11fde'}
+                = image_tag "slide/home-slide7.png"
+                .slideOverlay
+                .slideText
+                  %p
+                    Americae Sive Novi Orbis Nova Descriptio, 1587. Ortelius Abraham, cartographer&nbsp;»
             %li
-              = image_tag "slide/home-slide8.jpg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/5316c911c73b2d4b44b3654b4ac9dea0'} Unidentified popper at the Roseland Ballroom, 1982. Joe Conzo, photographer&nbsp;»
+              %a{:href => '/item/5316c911c73b2d4b44b3654b4ac9dea0'}
+                = image_tag "slide/home-slide8.jpg"
+                .slideOverlay
+                .slideText
+                  %p
+                    Unidentified popper at the Roseland Ballroom, 1982. Joe Conzo, photographer&nbsp;»
             %li
-              = image_tag "slide/home-slide9.jpg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/7c26b9eff9d4c572b0a686d9207417a4'} An Ordinance Abolishing Slavery in Missouri, 1865. (Missouri Emancipation Proclamation)&nbsp;»
+              %a{:href => '/item/7c26b9eff9d4c572b0a686d9207417a4'}
+                = image_tag "slide/home-slide9.jpg"
+                .slideOverlay
+                .slideText
+                  %p
+                    An Ordinance Abolishing Slavery in Missouri, 1865. (Missouri Emancipation Proclamation)&nbsp;»
             %li
-              = image_tag "slide/home-slide10.jpg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/58eba7947b48cc83bc8730587a3a6aab'} Winnie-the-Pooh, Kanga, Piglet, Eeyore, and Tigger, 1925&nbsp;»
+              %a{:href => '/item/58eba7947b48cc83bc8730587a3a6aab'}
+                = image_tag "slide/home-slide10.jpg"
+                .slideOverlay
+                .slideText
+                  %p
+                    Winnie-the-Pooh, Kanga, Piglet, Eeyore, and Tigger, 1925&nbsp;»
             %li
-              = image_tag "slide/home-slide11.png"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/75437b69bc3588e1ebc6fd2d1eb302b1'} Women on The Scrambler, Excelsior Amusement Park, Excelsior, Minnesota, c. 1950-1959.  &nbsp;»
+              %a{:href => '/item/75437b69bc3588e1ebc6fd2d1eb302b1'}
+                = image_tag "slide/home-slide11.png"
+                .slideOverlay
+                .slideText
+                  %p
+                    Women on The Scrambler, Excelsior Amusement Park, Excelsior, Minnesota, c. 1950-1959.  &nbsp;»
             %li
-              = image_tag "slide/home-slide12.jpeg"
-              .slideOverlay
-              .slideText
-                %p
-                  %a{:href => '/item/d498d3ce75e3fede0f8b4bd79fdc7146'} Mexican Folk Dancing, 9th Annual Texas Folklife Festival, 1980. Photograph by Michael Sidoric, Informedia&nbsp;»
-          %a.moreInfo
-            %span i
+              %a{:href => '/item/d498d3ce75e3fede0f8b4bd79fdc7146'} 
+                = image_tag "slide/home-slide12.jpeg"
+                .slideOverlay
+                .slideText
+                  %p
+                    Mexican Folk Dancing, 9th Annual Texas Folklife Festival, 1980. Photograph by Michael Sidoric, Informedia&nbsp;»
       .searchForm
         %h2 A Wealth of Knowledge
         %p 


### PR DESCRIPTION
This changes the behavior of the homepage slideshow to be more user-friendly and intuitive.  Before, in order to link to the page represented by the slide image, the user had to click on an button labeled "i", and then click on the link that appeared overtop of the image.  Now, the user can click directly on the image at any time to follow the link.  There is not "i" button; the link appears when the user mouses over the slide image.

This has been tested locally and on staging.  It addresses [#8133](https://issues.dp.la/issues/8133).