### PR TITLE
auto-link item metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'turnout'
 gem 'net-ssh', '~> 2.1'
 gem 'fog', '~> 1.34'
 gem 'fog-google', '~> 0.0.7'
+gem 'rinku', '~> 2.0'
 
 group :development do
   gem 'thin'

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -34,7 +34,11 @@ module ItemsHelper
               end.join("<br/>").html_safe
             end
           else
-            content_tag(:li, value.join("<br />").html_safe)
+            content_tag(:li) do
+              value.map do |v|
+                Rinku.auto_link(v, :urls, 'target="_blank"')
+              end.join("<br />").html_safe
+            end
           end
         end
       end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,8 +48,16 @@ class Item
     end
   end
 
+  # @return [Array<String>]
+  # downcase first letter if rights statement is URI
   def rights
-    @sourceResource['rights']
+    Array.wrap(@sourceResource['rights']).map do |rights|
+      if valid_http_uri?(rights)
+        rights[0, 1].downcase + rights[1..-1]
+      else
+        rights
+      end
+    end
   end
 
   #returns and array of statements
@@ -160,25 +168,24 @@ class Item
 
   private
 
-    def valid_http_uri?(uri)
-      URI.parse(uri).kind_of?(URI::HTTP)
-    rescue URI::InvalidURIError
-      false
-    end
+  def valid_http_uri?(uri)
+    URI.parse(uri).kind_of?(URI::HTTP)
+  rescue URI::InvalidURIError
+    false
+  end
 
-    def transform_dotted_keys(doc)
-      doc.keys
-        .select { |k| k.index('.') }
-        .select { |k| k =~ /^(sourceResource|object)/ }
-        .each do |k|
-          value = doc.delete k
-          tokens = k.split '.'
-          first_token = tokens.shift
-          tokens.reverse.each { |t| value = {t => value} }
-          doc[first_token] ||= {}
-          doc[first_token].deep_merge! value
-        end
-      doc
-    end
-
+  def transform_dotted_keys(doc)
+    doc.keys
+      .select { |k| k.index('.') }
+      .select { |k| k =~ /^(sourceResource|object)/ }
+      .each do |k|
+        value = doc.delete k
+        tokens = k.split '.'
+        first_token = tokens.shift
+        tokens.reverse.each { |t| value = {t => value} }
+        doc[first_token] ||= {}
+        doc[first_token].deep_merge! value
+      end
+    doc
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -45,8 +45,7 @@
         = item_field :rights
         -if @item.standardized_rights_statement.present?
           =item_field :standardized_rights_statement
-        = item_field :url, title: 'URL' do
-          = link_to @item.url, @item.url, target: :_blank
+        = item_field :url, title: 'URL'
 
   %aside
     - # is_location_present = @item.location.present? && @item.coordinates.present?

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -71,4 +71,18 @@ describe Item do
       expect(item.language).to match_array ['x']
     end
   end
+
+  describe '#rights' do
+    it 'handles multiple values' do
+      doc = { 'sourceResource' => { 'rights' => ['X', 'Y'] } }
+      item = Item.new(doc)
+      expect(item.rights).to match_array ['X', 'Y']
+    end
+
+    it 'downcases first character of URLs' do
+      doc = { 'sourceResource' => { 'rights' => 'Http://Example.com' } }
+      item = Item.new(doc)
+      expect(item.rights).to match_array ['http://Example.com']
+    end
+  end
 end


### PR DESCRIPTION
This activates links within metadata values in `/item` pages.

Metadata values such as rights statements may be URIs, or may include URIs within free text fields.  For example:

https://dp.la/item/b1947a688b43a6ce8aae6b5f25afd3d0
https://dp.la/item/8d0bd6f2d31be8b8ca88e519ccbab27e

This activates those links using the [Rinku](https://github.com/vmg/rinku) gem.  For the rights field specifically, it downcases the first letter if it is a URI.

Note: This _only_ links metadata fields that are _not_ facetable; facetable metadata values are already linked on `/item` pages.

This addresses [ticket #8705](https://issues.dp.la/issues/8507).  It has been tested locally.