### PR TITLE
fix URL metadata field on item page

### DIFF
--- a/app/assets/stylesheets/vendor/main.css
+++ b/app/assets/stylesheets/vendor/main.css
@@ -2425,6 +2425,9 @@ aside h5 { margin: 5px 0 1em; }
     font: 0.800em/1em 'source_sans_pro_semiboldRg', arial, sans-serif;
     display: block;
 }
+.items-controller.show-action li .ViewObject {
+    font: inherit;
+}
 .ViewObject:hover {
 	text-decoration: none;
 }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -50,7 +50,7 @@
         = item_field :rights
         -if @item.standardized_rights_statement.present?
           =item_field :standardized_rights_statement
-        = item_field :url, title: 'URL'
+        = item_field :url, title: 'URL' do
           = link_to @item.url, @item.url, target: :_blank, class: 'ViewObject'
 
   %aside


### PR DESCRIPTION
This fixes a couple of errors introduced when several different branches were merged to develop.  It eliminates typo in the items show view that was introduced while resolving a merge conflict.  It also adjusts the CSS so that the font size of the URL metadata field on the item show view is the same as the other metadata fields.