### PR TITLE
remove comment from jst.ejs file

### DIFF
--- a/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/timeline/item.jst.ejs
@@ -1,4 +1,3 @@
-<%# data-* attributes are used in Google Analytics event tracking %>
 <section class="<%= item.highlight ? 'highlight' : '' %>"
          data-item-id="<%= item.id %>"
          data-provider="<%= item.provider %>"


### PR DESCRIPTION
This removes a comment in `item.jst.ejs`.  The `#` in the comment line was causes asset compilation to fail in the production environment.  This has been tested on staging.