### PR TITLE
handle multiple thumbnails

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -136,7 +136,8 @@ class Item
   # @return [String, nil]  link to DPLA thumbnail HTTPS proxy service if it is a
   # valid HTTP uri; nil otherwise
   def preview_image
-    return @object if valid_http_uri?(@object)
+    object = Array.wrap(@object).first
+    return object if valid_http_uri?(object)
     nil
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -39,6 +39,13 @@ describe Item do
         expect(item.preview_image).to be_nil
       end
     end
+
+    context 'with multiple objects' do
+      let(:value) { ['http://bar.com/foo', 'http://bar.com/bat'] }
+      let(:ret) { 'http://bar.com/foo' }
+
+      it_behaves_like 'an item with an object'
+    end
   end
 
   describe '#language' do


### PR DESCRIPTION
This allows the frontend to handle multiple thumbnails (ie. `edm:object`s).  

Some providers are giving us multiple thumbnails.  Before this fix, the frontend would only render thumbnails if there was a single value.  If there were multiple values, it would default to showing the placeholder image (ie: https://dp.la/item/a88574851da78a86a59a2e94c5e3a7e3).

With this fix, if there are multiple thumbnails, the frontend will render the first.

This has been tested locally.  It addresses [ticket #8525](https://issues.dp.la/issues/8525).