### PR TITLE
pin breadcrumbs_on_rails gem to v 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 gem 'haml'
 gem 'haml-rails'
 gem 'simple_form'
-gem 'breadcrumbs_on_rails'
+gem 'breadcrumbs_on_rails', '~> 2.3'
 gem 'kaminari'
 gem 'navigasmic'
 gem 'carrierwave'


### PR DESCRIPTION
This pins the breadcrumbs_on_rails gem to v2.3.  Version 3.0, released on Aug 7, requires ruby v2.0, which is not yet running in the frontend.