### PR TITLE
handle missing google analytics tracker

### DIFF
--- a/app/assets/javascripts/google-analytics-events.js
+++ b/app/assets/javascripts/google-analytics-events.js
@@ -30,12 +30,19 @@ $(function(){
  * Relies on data-* attributes embedded in the HTML of the page.
  */
 var trackItemViewEvent = function(){
-  var item = $("[data-item-id]");
-  var category = "View Item : " + item.attr("data-provider");
-  var action = item.attr("data-data-provider");
-  var label = item.attr("data-item-id") + " : " + item.attr("data-title");
+  /* 
+   * 'ga' must be defined for a signal to be sent to Google Analtyics.
+   * It is set by the google analtyics rails gem if valid tracker is present.
+   */
+  if (typeof ga !== 'undefined') {
 
-  ga('send', 'event', category, action, label);
+    var item = $("[data-item-id]");
+    var category = "View Item : " + item.attr("data-provider");
+    var action = item.attr("data-data-provider");
+    var label = item.attr("data-item-id") + " : " + item.attr("data-title");
+
+    ga('send', 'event', category, action, label);
+  }
 }
 
 /* 
@@ -44,10 +51,16 @@ var trackItemViewEvent = function(){
  * Relies on data-* attributes belonging to a parent of the given object.
  */
 var trackClickThroughEvent = function(obj){
-  var item = $(obj).parents("[data-item-id]");
-  var category = "Click Through : " + item.attr("data-provider");
-  var action = item.attr("data-data-provider");
-  var label = item.attr("data-item-id") + " : " + item.attr("data-title");
+  /* 
+   * 'ga' must be defined for a signal to be sent to Google Analtyics.
+   * It is set by the google analtyics rails gem if valid tracker is present.
+   */
+  if (typeof ga !== 'undefined') {
+    var item = $(obj).parents("[data-item-id]");
+    var category = "Click Through : " + item.attr("data-provider");
+    var action = item.attr("data-data-provider");
+    var label = item.attr("data-item-id") + " : " + item.attr("data-title");
 
-  ga('send', 'event', category, action, label, {'transport': 'beacon'});
+    ga('send', 'event', category, action, label, {'transport': 'beacon'});
+  }
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
   = csrf_meta_tags
   = javascript_include_tag 'modernizr-2.6.2.min.js'
   <!--[if lte IE 7]>#{ javascript_include_tag 'lte-ie7.js' }<![endif]-->
-  = analytics_init
+  = analytics_init if GoogleAnalytics.valid_tracker?
 -# body class names make each page identifiable by controller and action
 %body{class: "#{controller_name}-controller #{action_name}-action"}
   %ul.jump-links


### PR DESCRIPTION
This gracefully handles a missing Google Analytics tracker ID.  Before this PR, if the Google Analytics tracker was missing from the application settings, the google analytics rails gem would still send a signal to GA, with a dummy tracker ID.  This PR adds a conditional that checks for the presence of the tracker.

This addresses [ticket #8529](https://issues.dp.la/issues/8529).  It has been tested locally.