### PR TITLE
Add exact field match to fix filtering on facets

### DIFF
--- a/spec/lib/dpla/conditions_spec.rb
+++ b/spec/lib/dpla/conditions_spec.rb
@@ -38,13 +38,28 @@ describe DPLA::Conditions do
         :page_size => 150
       }
       result = @conditions.instance_eval{ transform_hash(conditions) }
-      expect(result).to eq("q=love&facets=sourceResource.type,admin.contributingInstitution&page_size=150")
+      expect(result)
+        .to eq("exact_field_match=true&q=love&facets=sourceResource.type," +
+               "admin.contributingInstitution&page_size=150")
+    end
+
+    it "converts a hash with field values into a string" do
+      conditions = {
+        :q => 'meh',
+        :provider => ['X'],
+        :facets => ['sourceResource.type'],
+        :page_size => 150
+      }
+      result = @conditions.instance_eval{ transform_hash(conditions) }
+      expect(result)
+        .to eq("exact_field_match=true&q=meh&provider=X&" +
+               "facets=sourceResource.type&page_size=150")
     end
 
     it "uri encodes a string" do
       conditions = {:q => "red wagon"}
       result = @conditions.instance_eval{ transform_hash(conditions) }
-      expect(result).to eq ("q=red%20wagon")
+      expect(result).to eq ("exact_field_match=true&q=red%20wagon")
     end
 
   end


### PR DESCRIPTION
Fixes https://issues.dp.la/issues/8398

Facilitate correct filtering based on clickthroughs from facets by doing an exact match on the facet values -- not a tokenized search.

See https://github.com/dpla/platform/pull/41

Also add some comments to the existing code.
