### PR TITLE
handle multiple objects in ssl item preview

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -142,7 +142,8 @@ class Item
   end
 
   def preview_image_ssl
-    return "//#{Settings.url.host}/thumb/#{@id}" if valid_http_uri?(@object)
+    object = Array.wrap(@object).first
+    return "//#{Settings.url.host}/thumb/#{@id}" if valid_http_uri?(object)    
     nil
   end
 


### PR DESCRIPTION
This handles multiple values for `object` in an ssl environment. 

This addresses [ticket #8525](https://issues.dp.la/issues/8525).  It has been tested on staging.