### PR TITLE
change dplafest menu link

### DIFF
--- a/app/views/shared/_top_navigation.html.haml
+++ b/app/views/shared/_top_navigation.html.haml
@@ -53,7 +53,7 @@
       %li= link_to "Groups", wordpress_path('/get-involved/groups/')
       %li= link_to "Workshops", wordpress_path('/get-involved/workshops/')
       %li= link_to "Events", wordpress_path('/get-involved/events/')
-      %li= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/april-2016/')
+      %li= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/')
       %li= link_to "Follow Us", wordpress_path('/get-involved/follow/')
 
   %li.aboutMenu


### PR DESCRIPTION
Change the DPLAfest link in the main menu.  This addresses [ticket #8552](https://issues.dp.la/issues/8552).