### PR TITLE
Fix/rights downcasing

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -51,13 +51,7 @@ class Item
   # @return [Array<String>]
   # downcase first letter if rights statement is URI
   def rights
-    Array.wrap(@sourceResource['rights']).map do |rights|
-      if valid_http_uri?(rights)
-        rights[0, 1].downcase + rights[1..-1]
-      else
-        rights
-      end
-    end
+    Array.wrap(@sourceResource['rights'])
   end
 
   #returns and array of statements

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -85,11 +85,5 @@ describe Item do
       item = Item.new(doc)
       expect(item.rights).to match_array ['X', 'Y']
     end
-
-    it 'downcases first character of URLs' do
-      doc = { 'sourceResource' => { 'rights' => 'Http://Example.com' } }
-      item = Item.new(doc)
-      expect(item.rights).to match_array ['http://Example.com']
-    end
   end
 end


### PR DESCRIPTION
This removes functionality to downcase the first letter of URLs in rights statements.  The downcasing was a temporary fix with employed b/c of data we were getting from PA.  PA is now fixing this on their end.  

This addresses [ticket #8571](https://issues.dp.la/issues/8571).