### PR TITLE
Pin rake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.17'
+gem 'rake', '~> 11.3.0'
 gem 'pg', '~> 0.18.4', :require => 'pg'
 
 group :assets do


### PR DESCRIPTION
The `rake` gem has had a new release that obsoletes some syntax that's used in our application. The error below is encountered when running `rake assets:precompile`.

See
http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11

The solution is for us to run version 11.3.x of `rake`, which we've known to be good in production.  `Gemfile` is thus being modified in this commit to pin it.

The error message:
```
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000001cce808>
/home/dpla/frontend-git/Rakefile:8:in `<top (required)>'
```