### PR TITLE
travis update bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ sudo: false
 addons:
     code_climate:
         repo_token: cdf26a4bea16a6cf03275316e208edeb0aff96ebf3c937fd02943401c6f759c6
+
+before_install:
+  - gem install bundler
+  - bundle --version


### PR DESCRIPTION
This forces travis to update its bundler gem before running gem dependency checks.  Before, it was running an older version of bundler, and was incorrectly detecting gem dependency conflicts that were not actually conflicts.