### PR TITLE
add homepage slide for dplafest 2017

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -8,12 +8,12 @@
         .flexslider.homeslide
           %ul.slides
             %li
-              %a{:href => '/exhibitions/exhibits/show/outsiders-president-elections'}
-                = image_tag "slide/pres_elections_exhibition.jpg"
+              %a{:href => '/info/get-involved/dplafest/april-2017/'}
+                = image_tag "slide/dplafest-2017.jpg"
                 .slideOverlay
                 .slideText
                   %p
-                    Battle on the Ballot: Political Outsiders in US Presidential Elections&nbsp;»
+                    Learn more about DPLAfest 2017&nbsp;»
             %li
               %a{:href => '/primary-source-sets'}
                 = image_tag "slide/home-slide-pss.jpg"


### PR DESCRIPTION
This replaces the "Battle on the Ballot" slide with the DPLAfest 2017 slide.

This should not be deployed until [frontend-assets PR#9](https://github.com/dpla/frontend-assets/pull/9) has been merged.

This addresses [ticket DT-1113](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1113).