### PR TITLE
change position of standardized rights statement on item page

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -52,7 +52,6 @@
         = item_field :type, facet: :type
         = item_field :subject, facet: :subject
         = item_field :language, facet: :language
-        = item_field :rights
         -if @item.standardized_rights_statement.present?
           =item_field :standardized_rights_statement do
             - @item.standardized_rights_statement.each do |srs|
@@ -60,6 +59,7 @@
                 %div.rights_statement
                   = RIGHTS_STATEMENTS[srs]['definition']
                   = link_to srs, srs
+        = item_field :rights
         = item_field :url, title: 'URL' do
           = link_to @item.url, @item.url, target: :_blank, class: 'ViewObject'
 


### PR DESCRIPTION
This changes the frontend item view so that "Rights" is displayed _after_ "Standardized Rights Statement".  

This branch has been deployed to staging for review.  You can see and example here: https://staging.dp.la/item/6300dab1395799d6bc0ba3b5e7d45d5a 

This addresses [ticket DT-1133](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1133).