### PR TITLE
temporary fix for nypl rights statement

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -51,6 +51,12 @@ class Item
   # @return [Array<String>]
   # downcase first letter if rights statement is URI
   def rights
+    # This conditional is a temporary fix for NYPL rights.  It returns a general
+    # rights statement only in absence of a standarized rights statement.
+    # This should be removed one the NYPL mapping is fixed.
+    return if provider == "The New York Public Library" && 
+        standardized_rights_statement.present?
+
     Array.wrap(@sourceResource['rights'])
   end
 


### PR DESCRIPTION
This is a temporary fix for NYPL rights statements.  It show the general rights field only if there is no standardized rights statement.  This is available for testing on staging:

NYPL record with both standardized and general rights statement (only standardized is displayed): https://staging.dp.la/item/2146cf147821298331afe95f2d2c92ef

NYPL record with only general rights statement: https://staging.dp.la/item/1998b3947afbb0089223ba351e39e2cb

Non-NYPL record with general rights statement: https://staging.dp.la/item/ce8bd5b62e05b0dd910dd5084e001b63

This addresses ticket [DT-1175](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1175)