### PR TITLE
Improve response times of various facets

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -1,6 +1,6 @@
 class SubjectsController < ApplicationController
   def index
-    search = Search.new nil, { facets: %w(subject), page_size: 0, facet_size: 500 }
+    search = Search.new nil, { facets: %w(subject), page_size: 0, facet_size: 300 }
     @subjects = search.result.facets.subject
   end
 end

--- a/app/helpers/refine_helper.rb
+++ b/app/helpers/refine_helper.rb
@@ -1,9 +1,23 @@
 module RefineHelper
+
+  # Return a Hash of parameters for ActionView::Helpers::UrlHelper#link_to
+  # The parameters either merge the given parameter with the existing ones or
+  # remove the given parameter if `remove: true` is in the options hash.
   def refine_path(area, value, options = {})
     existing_refine = params[area] || []
     existing_refine = Array(existing_refine)
     refine_params = options.delete(:remove).present? ? existing_refine - [value] : existing_refine + [value]
     params.merge(options).deep_merge(area => refine_params.uniq, page: nil)
+  end
+
+  # Return a querystring string value for the parameters in refine_path.
+  # The controller, action, and page parameters are excluded.
+  # For creating self-referential links with HAML %a elements that are faster
+  # to construct than calls to ActionView::Helpers::UrlHelper#link_to.
+  def refine_path_qs(*args)
+    refine_path(*args)
+      .reject {|k,v| ['controller', 'action', 'page'].include?(k)}
+      .to_query
   end
 
   def refines_present?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -93,7 +93,7 @@ class Search
 
   def conditions
     facets = %w(subject language type provider partner country state place)
-    { q: @term, facets: facets, facet_size: 2000 }.merge(@filters).merge(@args)
+    { q: @term, facets: facets, facet_size: 300 }.merge(@filters).merge(@args)
   end
 
   private

--- a/app/views/shared/results/_search_results.html.haml
+++ b/app/views/shared/results/_search_results.html.haml
@@ -18,7 +18,7 @@
         with dates
       - if provider_facets.present?
         from
-        = "#{ 'over' if provider_facets.count >= 2000 }"
+        = "#{ 'over' if provider_facets.count >= 300 }"
         = "#{ number_with_delimiter provider_facets.count, delimiter: ',' }"
         contributing
         - if provider_facets.count > 1

--- a/app/views/shared/sidebar/_refine_by_location.html.haml
+++ b/app/views/shared/sidebar/_refine_by_location.html.haml
@@ -31,8 +31,8 @@
     - if country_facets.present? or place_facets.present?
       .more= link_to 'More »', '#more_locations', class: 'inline cboxElement'
 
-// Popup
 - content_for :colorbox do
+  / Popup
   #more_locations.inline_content
     %h1 Locations
     %ul.tabs
@@ -81,7 +81,7 @@
                       - if us_refined
                         %span{style: 'float:left;'} United States
                       - else
-                        = link_to 'United States', refine_path(:country, 'United States')
+                        %a{href: "./timeline?#{refine_path_qs(:country, 'United States')}"} United States
                       - if us_facet
                         %span= us_facet.last
                     - us_facet = us_refined = nil
@@ -91,7 +91,7 @@
                     - if name.present?
                       - next if name == 'United States'
                       %li
-                        = link_to name, refine_path(:country, name)
+                        %a{href: "./timeline?#{refine_path_qs(:country, name)}"}= name
                         %span= count
 
       #states
@@ -123,7 +123,7 @@
                     - name, count = facet.shift, facet.shift
                     - if name.present?
                       %li
-                        = link_to name, refine_path(:state, name)
+                        %a{href: "./timeline?#{refine_path_qs(:state, name)}"}= name
                         %span= count
 
     #places_num.viewport
@@ -149,7 +149,7 @@
                   - name, count = facet.shift, facet.shift
                   - if name.present?
                     %li
-                      = link_to name, refine_path(:place, name)
+                      %a{href: "./timeline?#{refine_path_qs(:place, name)}"}= name
                       %span= count
 
     #places_az.viewport
@@ -174,5 +174,5 @@
                   - name, count = facet.shift, facet.shift
                   - if name.present?
                     %li
-                      = link_to name, refine_path(:place, name)
+                      %a{href: "./timeline?#{refine_path_qs(:place, name)}"}= name
                       %span= count


### PR DESCRIPTION
Improve response times of the Timeline and other places where very large facets have been queried, processed, and rendered in the past.

* Reduce facet sizes
* Create querystrings more efficiently in self-referential hyperlinks in certain places that have large-domain `each` loops, where `#link_to` is too slow.

Note that the huge facets of 2000 elements were never used fully, because the most that was drawn into a given modal window on an HTML page was 10 "pages" of 30 elements. Only 300 facets were really being used out of the 2000 that Elasticsearch was being asked to assemble. The number of pages has been reduced to 8, and the facet size in a number of queries has been reduced to 240, which is 8 times 30.

See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1190

When this has had a first review pass, I'll put this on our staging environment so it can be observed some more before this PR is closed.
