### PR TITLE
add meta referrer tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,20 @@
 /[if IE 8]    <html class="no-js lt-ie9 ie8">
 / [if gt IE 8] <!--> <html class="no-js"> <!--
 %head
-  = display_meta_tags :charset => "utf-8", :content => "IE=edge,chrome=1", "http-equiv" => "X-UA-Compatible", :description => "", :viewport => "width=device-width", :twitter => {:card => "summary", :site => "@dpla", :domain => "dp.la"}, :og => {:title => page_title, :image => "http://dp.la/apple-touch-icon-144x144-precomposed.png", :description => "The Digital Public Library of America brings together the riches of America’s libraries, archives, and museums, and makes them freely available to the world.", :type => "website", :url => "#{request.protocol}#{request.host_with_port}#{request.fullpath}"}
+  = display_meta_tags :charset => "utf-8",
+                      :content => "IE=edge,chrome=1",
+                      "http-equiv" => "X-UA-Compatible",
+                      :description => "",
+                      :viewport => "width=device-width",
+                      :referrer => "origin-when-cross-origin",
+                      :twitter => { :card => "summary",
+                                    :site => "@dpla",
+                                    :domain => "dp.la" },
+                      :og => {  :title => page_title,
+                                :image => "http://dp.la/apple-touch-icon-144x144-precomposed.png",
+                                :description => "The Digital Public Library of America brings together the riches of America’s libraries, archives, and museums, and makes them freely available to the world.",
+                                :type => "website",
+                                :url => "#{request.protocol}#{request.host_with_port}#{request.fullpath}" }
   %title= page_title
   = stylesheet_link_tag    "application", media: "all"
   = branding_stylesheets


### PR DESCRIPTION
This adds the following `meta` tag to all pages:
```<meta name="referrer" content="origin-when-cross-origin" />```

The purpose of this tag is to enable `HTTP` sites (including a fair number of our contributors) to track traffic from DPLA using tools such as Google Analytics.

This also reformats what was a single line of code for legibility.

This has been deployed to staging for testing.  For example: view-source:https://staging.dp.la/item/2146cf147821298331afe95f2d2c92ef

This addresses [ticket DT-1116](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1116).