### PR TITLE
display creative commons statements

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -60,15 +60,17 @@ class Item
     Array.wrap(@sourceResource['rights'])
   end
 
-  #returns and array of statements
+  # returns an array of statements
+  # only returns statements in the RIGHTS_STATEMENTS dictionary
+  # @see rights_statements.yml and rails_config.rb
   def standardized_rights_statement
-    statement = [@edmRights]
+    statement = Array.wrap(@edmRights)
     if @hasView.is_a? Array
       @hasView.each { |view| statement.push( view['edmRights'] ) }
     else
       statement.push @hasView['edmRights']
     end
-    statement.compact
+    statement.compact.delete_if { |s| RIGHTS_STATEMENTS.keys.exclude? s }
   end
 
   # returns an array of displayDate values

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -19,7 +19,7 @@
         = link_to @item.url, target: :_blank, class: 'ViewObject' do
           = item_thumbnail(@item, request)
         - @item.standardized_rights_statement.each do |srs|
-          - if RIGHTS_STATEMENTS[srs].present?
+          - if srs.include? 'rightsstatements.org'
             = link_to(image_tag(RIGHTS_STATEMENTS[srs]['image_path'], alt: RIGHTS_STATEMENTS[srs]['label']), srs)
         = view_object_link(@item)
       .table
@@ -55,10 +55,10 @@
         -if @item.standardized_rights_statement.present?
           =item_field :standardized_rights_statement do
             - @item.standardized_rights_statement.each do |srs|
-              - if RIGHTS_STATEMENTS[srs].present?
-                %div.rights_statement
+              %div.rights_statement
+                - if srs.include? 'rightsstatements.org'
                   = RIGHTS_STATEMENTS[srs]['definition']
-                  = link_to srs, srs
+                = link_to srs, srs
         = item_field :rights
         = item_field :url, title: 'URL' do
           = link_to @item.url, @item.url, target: :_blank, class: 'ViewObject'

--- a/config/rights_statements.yml
+++ b/config/rights_statements.yml
@@ -22,7 +22,7 @@
   label: "In copyright - non-commercial use permitted"
   image_path: "rights_statements/InC-NC.dark-white-interior-blue-type.png"
   definition: "This Item is protected by copyright and/or related rights. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use. In addition, no permission is required from the rights-holder(s) for non-commercial uses. For other uses you need to obtain permission from the rights-holder(s)."
-
+  
 "http://rightsstatements.org/vocab/InC-RUU/1.0/":
   label: "In copyright - rights-holder(s) unlocatable or unidentifiable"
   image_path: "rights_statements/InC-RUU.dark-white-interior-blue-type.png"
@@ -62,3 +62,19 @@
     label: "No known copyright"
     image_path: "rights_statements/NKC.dark-white-interior-blue-type.png"
     definition: "The organization that has made the Item available reasonably believes that the Item is not restricted by copyright or related rights, but a conclusive determination could not be made. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use."
+
+"https://creativecommons.org/publicdomain/zero/1.0/":
+
+"https://creativecommons.org/licenses/by/4.0/":
+
+"https://creativecommons.org/licenses/by-sa/4.0/":
+
+"https://creativecommons.org/licenses/by-nc/4.0/":
+
+"https://creativecommons.org/licenses/by-nd/4.0/":
+
+"https://creativecommons.org/licenses/by-nc-sa/4.0/":
+
+"https://creativecommons.org/licenses/by-nc-nd/4.0/":
+
+"https://creativecommons.org/publicdomain/mark/1.0/":

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -86,4 +86,14 @@ describe Item do
       expect(item.rights).to match_array ['X', 'Y']
     end
   end
+
+  describe '#standardized_rights_statement' do
+    it 'returns only statements in RIGHTS_STATEMENTS dictionary' do
+      valid_statement = "https://creativecommons.org/publicdomain/zero/1.0/"
+      doc = { 'rights' => ['invalid statement', valid_statement] }
+      item = Item.new(doc)
+      expect(item.standardized_rights_statement)
+        .to match_array [valid_statement]
+    end
+  end
 end


### PR DESCRIPTION
This displays creative commons licenses.  

Creative commons URLs are added to the YML file which already has the info necessary to display rightsstatement.org statements.  It may seem a bit graceless to put the creative commons URLs here, but I think it will serve us well once we inevitably have to add display info, such as textual descriptions and image paths, as we did with rightsstatement.org.

Logic is added to the model to check the validity of standardized rights URIs coming through the API.  This fulfills the requirement of only displaying valid rights statements.

This has been deployed to staging.

- Item with creative commons statement: https://staging.dp.la/item/03b1a4cb920bdbbbf9f3251106350bfc
- Item with rightsstatement.org statement: https://staging.dp.la/item/6300dab1395799d6bc0ba3b5e7d45d5a
- Item without standardized rights statement: https://staging.dp.la/item/7cb106c617f9ebc7237832121b774359

This addresses [ticket DT-1200](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1200).