### PR TITLE
Fix creative commons license

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -94,4 +94,29 @@ module ItemsHelper
     end
     ogp
   end
+
+  ##
+  # Return all permitted standardized rights statements.
+  # @return Array
+  def permitted_srs(item)
+    item.standardized_rights_statement.delete_if do |srs|
+      !(rs_statement?(srs) || cc_statement?(srs))
+    end
+  end
+
+  ##
+  # Return true if given rights statement is included in the
+  # rightsstatement.org URIs listed in `rightsstatements.yml`.
+  def rs_statement?(rights_statement)
+    return true if RIGHTS_STATEMENTS.keys.include? rights_statement
+    false
+  end
+
+  ##
+  # Return true if given rights statement includes substring
+  # "creativecommons.org".
+  def cc_statement?(rights_statement)
+    return true if rights_statement.include? "creativecommons.org"
+    false
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -70,7 +70,7 @@ class Item
     else
       statement.push @hasView['edmRights']
     end
-    statement.compact.delete_if { |s| RIGHTS_STATEMENTS.keys.exclude? s }
+    statement.compact
   end
 
   # returns an array of displayDate values

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -19,7 +19,7 @@
         = link_to @item.url, target: :_blank, class: 'ViewObject' do
           = item_thumbnail(@item, request)
         - @item.standardized_rights_statement.each do |srs|
-          - if srs.include? 'rightsstatements.org'
+          - if rs_statement?(srs)
             = link_to(image_tag(RIGHTS_STATEMENTS[srs]['image_path'], alt: RIGHTS_STATEMENTS[srs]['label']), srs)
         = view_object_link(@item)
       .table
@@ -52,13 +52,14 @@
         = item_field :type, facet: :type
         = item_field :subject, facet: :subject
         = item_field :language, facet: :language
-        -if @item.standardized_rights_statement.present?
+        - psrs = permitted_srs(@item)
+        -if psrs.present?
           =item_field :standardized_rights_statement do
-            - @item.standardized_rights_statement.each do |srs|
-              %div.rights_statement
-                - if srs.include? 'rightsstatements.org'
+            - psrs.each do |srs|
+              - if rs_statement?(srs)
+                %div.rights_statement
                   = RIGHTS_STATEMENTS[srs]['definition']
-                = link_to srs, srs
+              = link_to srs, srs
         = item_field :rights
         = item_field :url, title: 'URL' do
           = link_to @item.url, @item.url, target: :_blank, class: 'ViewObject'

--- a/config/rights_statements.yml
+++ b/config/rights_statements.yml
@@ -62,19 +62,3 @@
     label: "No known copyright"
     image_path: "rights_statements/NKC.dark-white-interior-blue-type.png"
     definition: "The organization that has made the Item available reasonably believes that the Item is not restricted by copyright or related rights, but a conclusive determination could not be made. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use."
-
-"https://creativecommons.org/publicdomain/zero/1.0/":
-
-"https://creativecommons.org/licenses/by/4.0/":
-
-"https://creativecommons.org/licenses/by-sa/4.0/":
-
-"https://creativecommons.org/licenses/by-nc/4.0/":
-
-"https://creativecommons.org/licenses/by-nd/4.0/":
-
-"https://creativecommons.org/licenses/by-nc-sa/4.0/":
-
-"https://creativecommons.org/licenses/by-nc-nd/4.0/":
-
-"https://creativecommons.org/publicdomain/mark/1.0/":

--- a/spec/helpers/items_helper_spec.rb
+++ b/spec/helpers/items_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ItemsHelper do
+
+  describe '#rs_statement' do
+    it 'returns true for rightsstatements.org statement' do
+      statement = "http://rightsstatements.org/vocab/NoC-NC/1.0/"
+      expect(helper.rs_statement?(statement)).to be true
+    end
+  end
+
+  describe '#cc_statement' do
+    it 'returns true for creative commons statement' do
+      statement = "https://creativecommons.org/publicdomain/zero/1.0"
+      expect(helper.cc_statement?(statement)).to be true
+    end
+  end
+
+  describe "#permitted_srs" do
+    it 'returns array of permitted standardized rights statements' do
+      valid = "http://rightsstatements.org/vocab/NoC-NC/1.0/"
+      invalid = "foobar"
+      statements = [valid, invalid]
+      item = double('item', :standardized_rights_statement => statements)
+      expect(helper.permitted_srs(item)).to match_array [valid]
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -88,12 +88,11 @@ describe Item do
   end
 
   describe '#standardized_rights_statement' do
-    it 'returns only statements in RIGHTS_STATEMENTS dictionary' do
-      valid_statement = "https://creativecommons.org/publicdomain/zero/1.0/"
-      doc = { 'rights' => ['invalid statement', valid_statement] }
+    it 'returns statements' do
+      statement = "https://creativecommons.org/publicdomain/zero/1.0/"
+      doc = { 'rights' => [statement] }
       item = Item.new(doc)
-      expect(item.standardized_rights_statement)
-        .to match_array [valid_statement]
+      expect(item.standardized_rights_statement).to match_array [statement]
     end
   end
 end


### PR DESCRIPTION
This allows more variation in creative commons licenses that are displayed on item pages.

Before, cc licenses would only display if they exactly matched a set of URIs specified in `config/rights_statements.yml`.  This instead displays any statement that contains the substring `creativecommons.org`, allowing, for example, statements of different versions or statements without trailing backlashes.

Before, the logic to determine whether or not a standardized rights statement was valid for display purposes was in the `Item` model.  This PR moves the logic to a view helper since it's now more complex and more appropriate for a helper anyway.

This branch has been deployed to staging for review purposes:
* Item with creative commons statement: https://staging.dp.la/item/03b1a4cb920bdbbbf9f3251106350bfc
* Item with creative commons statement (no trailing backslash): https://staging.dp.la/item/31a495e5c79cc5739010f3d491ad3626
* Item with rightsstatement.org statement: https://staging.dp.la/item/6300dab1395799d6bc0ba3b5e7d45d5a
* Item with no standardized rights statement: https://staging.dp.la/item/7cb106c617f9ebc7237832121b774359

This addresses ticket [DT-1236](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1236).