### PR TITLE
Turn off asset debugging in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ DplaPortal::Application.configure do
   config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = false
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
config.assets.debug causes many 404s for assets when `RAILS_ENV=development`. If `foo.css` is included in `application.scss`, it's concatenated into the resulting `application.css` file, but Rails still writes a link tag in the HTML for foo.css. Since it's been included, it doesn't exist on its own in the public/assets directory and you get a 404. I'm not sure exactly how to get Rails to serve individual files instead of concatenating, but at least the concatenated `application.css` is readable, so it suffices for now.

`application.css` isn't the only one; I was getting 404s before for Javascript like the jQuery plugins, as well, before changing `config.assets.debug`.