### PR TITLE
Dt 1339 change homepage slide

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -8,12 +8,12 @@
         .flexslider.homeslide
           %ul.slides
             %li
-              %a{:href => '/info/get-involved/dplafest/april-2017/'}
-                = image_tag "slide/dplafest-2017.jpg"
+              %a{:href => '/exhibitions/exhibits/show/american-empire'}
+                = image_tag "slide/home-slide-american-empire.jpg"
                 .slideOverlay
                 .slideText
                   %p
-                    Learn more about DPLAfest 2017&nbsp;»
+                    Explore the DPLA's newest exhibition&nbsp;»
             %li
               %a{:href => '/primary-source-sets'}
                 = image_tag "slide/home-slide-pss.jpg"

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -23,7 +23,7 @@
                     Check out the DPLA's new Primary Source Sets for Education&nbsp;»
             %li
               %a{:href => '/item/92028cc0c0064c6690a39a6d67b11fde'}
-                = image_tag "slide/home-slide7.png"
+                = image_tag "slide/home-slide7.jpg"
                 .slideOverlay
                 .slideText
                   %p
@@ -51,7 +51,7 @@
                     Winnie-the-Pooh, Kanga, Piglet, Eeyore, and Tigger, 1925&nbsp;»
             %li
               %a{:href => '/item/75437b69bc3588e1ebc6fd2d1eb302b1'}
-                = image_tag "slide/home-slide11.png"
+                = image_tag "slide/home-slide11.jpg"
                 .slideOverlay
                 .slideText
                   %p


### PR DESCRIPTION
This changes the first slide in the homepage slideshow from "DPLAfest" to "American Empire."  It also changes the URL of two additional slides to point to new, compressed versions of the images.

This addresses tickets [DT-362](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-632) and [DT-1339](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1339).